### PR TITLE
feature: Optimize entity writer and reader

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ recursive-exclude docs *
 recursive-exclude tests *
 recursive-exclude codegen *
 recursive-exclude container *
+recursive-exclude benchmarks *
 recursive-include src py.typed
 recursive-include src *.py
 exclude *.yaml

--- a/benchmarks/roundtrip-serialization.py
+++ b/benchmarks/roundtrip-serialization.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import datetime
+import io
+import uuid
+
+import pyperf
+
+from kio.schema.metadata.v12 import MetadataResponse
+from kio.schema.metadata.v12.response import MetadataResponseBroker
+from kio.schema.metadata.v12.response import MetadataResponsePartition
+from kio.schema.metadata.v12.response import MetadataResponseTopic
+from kio.schema.types import BrokerId
+from kio.schema.types import TopicName
+from kio.serial import entity_reader
+from kio.serial import entity_writer
+from kio.static.constants import ErrorCode
+from kio.static.primitive import i32
+from kio.static.primitive import i32Timedelta
+
+write_metadata_response = entity_writer(MetadataResponse)
+read_metadata_response = entity_reader(MetadataResponse)
+
+instance = MetadataResponse(
+    throttle_time=i32Timedelta.parse(datetime.timedelta(milliseconds=123)),
+    brokers=tuple(
+        MetadataResponseBroker(
+            node_id=BrokerId(n),
+            host="foo.bar",
+            port=i32(1234),
+            rack=None,
+        )
+        for n in range(20)
+    ),
+    cluster_id="556",
+    controller_id=BrokerId(3),
+    topics=tuple(
+        MetadataResponseTopic(
+            error_code=ErrorCode.kafka_storage_error,
+            name=TopicName(f"topic {n}"),
+            topic_id=uuid.uuid4(),
+            is_internal=False,
+            partitions=(
+                MetadataResponsePartition(
+                    error_code=ErrorCode.delegation_token_expired,
+                    partition_index=i32(5679),
+                    leader_id=BrokerId(2345),
+                    leader_epoch=i32(6445678),
+                    replica_nodes=(BrokerId(12345), BrokerId(7651)),
+                    isr_nodes=(),
+                    offline_replicas=(),
+                ),
+            ),
+            topic_authorized_operations=i32(765443),
+        )
+        for n in range(100)
+    ),
+)
+
+
+def perform_roundtrip(
+    loops: int = 10,
+    test_instance: MetadataResponse = instance,
+) -> float:
+    loop_range = range(loops)
+
+    with io.BytesIO() as buffer:
+        t0 = pyperf.perf_counter()
+
+        for _ in loop_range:
+            write_metadata_response(buffer, test_instance)
+
+        buffer.seek(0)
+
+        for _ in loop_range:
+            result = read_metadata_response(buffer)
+            assert result == test_instance
+
+        tN = pyperf.perf_counter() - t0
+
+        assert buffer.read(1) == b"", "buffer not exhausted after read"
+
+    return tN
+
+
+if __name__ == "__main__":
+    # import kio.static.primitive
+    # from scalene import scalene_profiler
+    # scalene_profiler.start()
+    # perform_roundtrip(1000)
+    # scalene_profiler.stop()
+
+    runner = pyperf.Runner()
+    runner.bench_time_func("roundtrip", perform_roundtrip, inner_loops=100)

--- a/src/kio/_utils.py
+++ b/src/kio/_utils.py
@@ -1,0 +1,16 @@
+# Work-around for broken support for cache decorators in
+# https://github.com/python/typeshed/issues/6347
+# https://stackoverflow.com/a/73517689
+from typing import TYPE_CHECKING
+from typing import TypeVar
+
+__all__ = ("cache",)
+
+if TYPE_CHECKING:
+    _C = TypeVar("_C")
+
+    def cache(c: _C) -> _C:
+        return c
+
+else:
+    from functools import cache

--- a/tests/serial/test_serialize.py
+++ b/tests/serial/test_serialize.py
@@ -112,7 +112,7 @@ class TestGetWriter:
             get_writer(kafka_type, flexible, optional)
 
 
-async def test_serialize_complex_entity(buffer: io.BytesIO) -> None:
+def test_serialize_complex_entity(buffer: io.BytesIO) -> None:
     write_metadata_response = entity_writer(MetadataResponse)
 
     topic_id = uuid.uuid4()


### PR DESCRIPTION
This change optimizes serialization and parsing by doing two things:

- Move introspection work so that it happens when the factories are producing a writer or reader, instead of happening at the time a writer or reader itself is called.
- Add unbounded caches to entity reader and writer factory functions, so that introspection work only happens once per model.

These changes combined result in an 83% reduction in time for the included serialization roundtrip benchmark.

#### Benchmark result pre optimization

```sh
$ python benchmarks/roundtrip-serialization.py
.....................
roundtrip: Mean +- std dev: 76.2 us +- 0.3 us
```

#### Benchmark result post optimization

```sh
python benchmarks/roundtrip-serialization.py
.....................
roundtrip: Mean +- std dev: 12.8 us +- 0.0 us
```