### PR TITLE
fix: Use ARM-available base image for Java tester

### DIFF
--- a/java_tester/Dockerfile
+++ b/java_tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM gradle:jdk17-alpine AS build
+FROM gradle:jdk17 AS build
 
 RUN mkdir /java_tester
 WORKDIR /java_tester


### PR DESCRIPTION
The Alpine image didn't seem to have ARM builds available, it was failing like below for me.

```
$ docker compose --project-directory=tests --file=tests/docker-compose-java-tester.yaml build
[+] Building 1.5s (4/4) FINISHED                                           docker:default
 => [java_tester internal] load build definition from Dockerfile                     0.0s
 => => transferring dockerfile: 359B                                                 0.0s
 => [java_tester internal] load .dockerignore                                        0.0s
 => => transferring context: 2B                                                      0.0s
 => [java_tester internal] load metadata for docker.io/library/eclipse-temurin:17-j  1.3s
 => ERROR [java_tester internal] load metadata for docker.io/library/gradle:jdk17-a  1.5s
------
 > [java_tester internal] load metadata for docker.io/library/gradle:jdk17-alpine:
------
failed to solve: gradle:jdk17-alpine: no match for platform in manifest sha256:77fde21d5f562a8fdcd75d1cac98b43b5f036e445396c5144e82d8c2fae1652d: not found
```