### PR TITLE
Introduce separate test stages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,8 +28,86 @@ jobs:
     name: Check packaging metadata
     uses: less-action/reusables/.github/workflows/python-test-build.yaml@0afb53ddb81137deb9d41e7d911eb1755bb451e3
 
-  test:
-    name: Test
+  unit-test:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.cfg
+
+      - name: Install requirements
+        run: pip install --upgrade -e '.[test]'
+
+      - name: Run test suite
+        run: python -X dev -m coverage run -m pytest -m "not java and not roundtrip and not integration"
+
+      - name: Collect coverage
+        run: |
+          coverage report
+          coverage xml
+
+      - name: Report coverage
+        uses: codecov/codecov-action@v3
+        with:
+          file: coverage.xml
+          fail_ci_if_error: true
+          name: codecov-py${{ matrix.python-version }}
+
+  roundtrip-test:
+    name: Roundtrip tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.cfg
+
+      - name: Install requirements
+        run: pip install --upgrade -e '.[test]'
+
+      - name: Run test suite
+        run: python -X dev -m pytest -m roundtrip
+
+  java-test:
+    name: Java tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: setup.cfg
+
+      - name: Install requirements
+        run: pip install --upgrade -e '.[test]'
+
+      - name: Run Java tests
+        run: python -X dev -m pytest -m java
+
+  integration-test:
+    name: Integration tests
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -50,20 +128,8 @@ jobs:
       - name: Install requirements
         run: pip install --upgrade -e '.[test]'
 
-      - name: Run test suite
-        run: python -X dev -m coverage run -m pytest
-
-      - name: Collect coverage
-        run: |
-          coverage report
-          coverage xml
-
-      - name: Report coverage
-        uses: codecov/codecov-action@v3
-        with:
-          file: coverage.xml
-          fail_ci_if_error: true
-          name: codecov-py${{ matrix.python-version }}
+      - name: Run integration tests
+        run: python -X dev -m pytest -m integration
 
   check-generate-schema:
     name: Check schema

--- a/codegen/generate_tests.py
+++ b/codegen/generate_tests.py
@@ -52,6 +52,7 @@ from kio.serial import entity_writer
 from tests.conftest import setup_buffer, JavaTester
 from kio.serial import entity_reader
 from typing import Final
+import pytest
 """
 import_code = """\
 from {entity_module} import {entity_type}
@@ -62,6 +63,7 @@ test_code = """\
 read_{entity_snake_case}: Final = entity_reader({entity_type})
 
 
+@pytest.mark.roundtrip
 @given(from_type({entity_type}))
 @settings(max_examples=1)
 def test_{entity_snake_case}_roundtrip(instance: {entity_type}) -> None:
@@ -74,6 +76,7 @@ def test_{entity_snake_case}_roundtrip(instance: {entity_type}) -> None:
 """
 
 test_code_java = """\
+@pytest.mark.java
 @given(instance=from_type({entity_type}))
 def test_{entity_snake_case}_java(instance: {entity_type}, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,11 @@ filterwarnings = [
   'ignore: ast\.[A-z]+ is deprecated:DeprecationWarning',
   'ignore: Attribute s is deprecated and will be removed:DeprecationWarning',
 ]
+markers = [
+  "integration: marks tests interacting with a running Apache Kafka® instance",
+  "roundtrip: marks roundtrip Hypothesis serialization tests",
+  "java: marks tests validating serialization against a Java process",
+]
 
 
 [tool.ruff]

--- a/tests/generated/test_add_offsets_to_txn_v0_request.py
+++ b/tests/generated/test_add_offsets_to_txn_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_add_offsets_to_txn_request: Final = entity_reader(AddOffsetsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddOffsetsToTxnRequest))
 @settings(max_examples=1)
 def test_add_offsets_to_txn_request_roundtrip(instance: AddOffsetsToTxnRequest) -> None:
@@ -26,6 +28,7 @@ def test_add_offsets_to_txn_request_roundtrip(instance: AddOffsetsToTxnRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddOffsetsToTxnRequest))
 def test_add_offsets_to_txn_request_java(
     instance: AddOffsetsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_offsets_to_txn_v0_response.py
+++ b/tests/generated/test_add_offsets_to_txn_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_add_offsets_to_txn_response: Final = entity_reader(AddOffsetsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddOffsetsToTxnResponse))
 @settings(max_examples=1)
 def test_add_offsets_to_txn_response_roundtrip(
@@ -28,6 +30,7 @@ def test_add_offsets_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddOffsetsToTxnResponse))
 def test_add_offsets_to_txn_response_java(
     instance: AddOffsetsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_add_offsets_to_txn_v1_request.py
+++ b/tests/generated/test_add_offsets_to_txn_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_add_offsets_to_txn_request: Final = entity_reader(AddOffsetsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddOffsetsToTxnRequest))
 @settings(max_examples=1)
 def test_add_offsets_to_txn_request_roundtrip(instance: AddOffsetsToTxnRequest) -> None:
@@ -26,6 +28,7 @@ def test_add_offsets_to_txn_request_roundtrip(instance: AddOffsetsToTxnRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddOffsetsToTxnRequest))
 def test_add_offsets_to_txn_request_java(
     instance: AddOffsetsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_offsets_to_txn_v1_response.py
+++ b/tests/generated/test_add_offsets_to_txn_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_add_offsets_to_txn_response: Final = entity_reader(AddOffsetsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddOffsetsToTxnResponse))
 @settings(max_examples=1)
 def test_add_offsets_to_txn_response_roundtrip(
@@ -28,6 +30,7 @@ def test_add_offsets_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddOffsetsToTxnResponse))
 def test_add_offsets_to_txn_response_java(
     instance: AddOffsetsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_add_offsets_to_txn_v2_request.py
+++ b/tests/generated/test_add_offsets_to_txn_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_add_offsets_to_txn_request: Final = entity_reader(AddOffsetsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddOffsetsToTxnRequest))
 @settings(max_examples=1)
 def test_add_offsets_to_txn_request_roundtrip(instance: AddOffsetsToTxnRequest) -> None:
@@ -26,6 +28,7 @@ def test_add_offsets_to_txn_request_roundtrip(instance: AddOffsetsToTxnRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddOffsetsToTxnRequest))
 def test_add_offsets_to_txn_request_java(
     instance: AddOffsetsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_offsets_to_txn_v2_response.py
+++ b/tests/generated/test_add_offsets_to_txn_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_add_offsets_to_txn_response: Final = entity_reader(AddOffsetsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddOffsetsToTxnResponse))
 @settings(max_examples=1)
 def test_add_offsets_to_txn_response_roundtrip(
@@ -28,6 +30,7 @@ def test_add_offsets_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddOffsetsToTxnResponse))
 def test_add_offsets_to_txn_response_java(
     instance: AddOffsetsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_add_offsets_to_txn_v3_request.py
+++ b/tests/generated/test_add_offsets_to_txn_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_add_offsets_to_txn_request: Final = entity_reader(AddOffsetsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddOffsetsToTxnRequest))
 @settings(max_examples=1)
 def test_add_offsets_to_txn_request_roundtrip(instance: AddOffsetsToTxnRequest) -> None:
@@ -26,6 +28,7 @@ def test_add_offsets_to_txn_request_roundtrip(instance: AddOffsetsToTxnRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddOffsetsToTxnRequest))
 def test_add_offsets_to_txn_request_java(
     instance: AddOffsetsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_offsets_to_txn_v3_response.py
+++ b/tests/generated/test_add_offsets_to_txn_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_add_offsets_to_txn_response: Final = entity_reader(AddOffsetsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddOffsetsToTxnResponse))
 @settings(max_examples=1)
 def test_add_offsets_to_txn_response_roundtrip(
@@ -28,6 +30,7 @@ def test_add_offsets_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddOffsetsToTxnResponse))
 def test_add_offsets_to_txn_response_java(
     instance: AddOffsetsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v0_request.py
+++ b/tests/generated/test_add_partitions_to_txn_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_add_partitions_to_txn_topic: Final = entity_reader(AddPartitionsToTxnTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopic))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_add_partitions_to_txn_topic_roundtrip(
 read_add_partitions_to_txn_request: Final = entity_reader(AddPartitionsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnRequest))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_request_roundtrip(
@@ -45,6 +48,7 @@ def test_add_partitions_to_txn_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnRequest))
 def test_add_partitions_to_txn_request_java(
     instance: AddPartitionsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v0_response.py
+++ b/tests/generated/test_add_partitions_to_txn_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_add_partitions_to_txn_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnPartitionResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_partition_result_roundtrip(
@@ -39,6 +41,7 @@ read_add_partitions_to_txn_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopicResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_result_roundtrip(
@@ -55,6 +58,7 @@ def test_add_partitions_to_txn_topic_result_roundtrip(
 read_add_partitions_to_txn_response: Final = entity_reader(AddPartitionsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnResponse))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_response_roundtrip(
@@ -68,6 +72,7 @@ def test_add_partitions_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnResponse))
 def test_add_partitions_to_txn_response_java(
     instance: AddPartitionsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v1_request.py
+++ b/tests/generated/test_add_partitions_to_txn_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_add_partitions_to_txn_topic: Final = entity_reader(AddPartitionsToTxnTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopic))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_add_partitions_to_txn_topic_roundtrip(
 read_add_partitions_to_txn_request: Final = entity_reader(AddPartitionsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnRequest))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_request_roundtrip(
@@ -45,6 +48,7 @@ def test_add_partitions_to_txn_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnRequest))
 def test_add_partitions_to_txn_request_java(
     instance: AddPartitionsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v1_response.py
+++ b/tests/generated/test_add_partitions_to_txn_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_add_partitions_to_txn_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnPartitionResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_partition_result_roundtrip(
@@ -39,6 +41,7 @@ read_add_partitions_to_txn_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopicResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_result_roundtrip(
@@ -55,6 +58,7 @@ def test_add_partitions_to_txn_topic_result_roundtrip(
 read_add_partitions_to_txn_response: Final = entity_reader(AddPartitionsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnResponse))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_response_roundtrip(
@@ -68,6 +72,7 @@ def test_add_partitions_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnResponse))
 def test_add_partitions_to_txn_response_java(
     instance: AddPartitionsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v2_request.py
+++ b/tests/generated/test_add_partitions_to_txn_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_add_partitions_to_txn_topic: Final = entity_reader(AddPartitionsToTxnTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopic))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_add_partitions_to_txn_topic_roundtrip(
 read_add_partitions_to_txn_request: Final = entity_reader(AddPartitionsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnRequest))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_request_roundtrip(
@@ -45,6 +48,7 @@ def test_add_partitions_to_txn_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnRequest))
 def test_add_partitions_to_txn_request_java(
     instance: AddPartitionsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v2_response.py
+++ b/tests/generated/test_add_partitions_to_txn_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_add_partitions_to_txn_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnPartitionResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_partition_result_roundtrip(
@@ -39,6 +41,7 @@ read_add_partitions_to_txn_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopicResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_result_roundtrip(
@@ -55,6 +58,7 @@ def test_add_partitions_to_txn_topic_result_roundtrip(
 read_add_partitions_to_txn_response: Final = entity_reader(AddPartitionsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnResponse))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_response_roundtrip(
@@ -68,6 +72,7 @@ def test_add_partitions_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnResponse))
 def test_add_partitions_to_txn_response_java(
     instance: AddPartitionsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v3_request.py
+++ b/tests/generated/test_add_partitions_to_txn_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_add_partitions_to_txn_topic: Final = entity_reader(AddPartitionsToTxnTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopic))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_add_partitions_to_txn_topic_roundtrip(
 read_add_partitions_to_txn_request: Final = entity_reader(AddPartitionsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnRequest))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_request_roundtrip(
@@ -45,6 +48,7 @@ def test_add_partitions_to_txn_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnRequest))
 def test_add_partitions_to_txn_request_java(
     instance: AddPartitionsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v3_response.py
+++ b/tests/generated/test_add_partitions_to_txn_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_add_partitions_to_txn_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnPartitionResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_partition_result_roundtrip(
@@ -39,6 +41,7 @@ read_add_partitions_to_txn_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopicResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_result_roundtrip(
@@ -55,6 +58,7 @@ def test_add_partitions_to_txn_topic_result_roundtrip(
 read_add_partitions_to_txn_response: Final = entity_reader(AddPartitionsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnResponse))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_response_roundtrip(
@@ -68,6 +72,7 @@ def test_add_partitions_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnResponse))
 def test_add_partitions_to_txn_response_java(
     instance: AddPartitionsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v4_request.py
+++ b/tests/generated/test_add_partitions_to_txn_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_add_partitions_to_txn_topic: Final = entity_reader(AddPartitionsToTxnTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopic))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_roundtrip(
@@ -35,6 +37,7 @@ read_add_partitions_to_txn_transaction: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTransaction))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_transaction_roundtrip(
@@ -51,6 +54,7 @@ def test_add_partitions_to_txn_transaction_roundtrip(
 read_add_partitions_to_txn_request: Final = entity_reader(AddPartitionsToTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnRequest))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_request_roundtrip(
@@ -64,6 +68,7 @@ def test_add_partitions_to_txn_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnRequest))
 def test_add_partitions_to_txn_request_java(
     instance: AddPartitionsToTxnRequest, java_tester: JavaTester

--- a/tests/generated/test_add_partitions_to_txn_v4_response.py
+++ b/tests/generated/test_add_partitions_to_txn_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -22,6 +23,7 @@ read_add_partitions_to_txn_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnPartitionResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_partition_result_roundtrip(
@@ -40,6 +42,7 @@ read_add_partitions_to_txn_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnTopicResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_topic_result_roundtrip(
@@ -56,6 +59,7 @@ def test_add_partitions_to_txn_topic_result_roundtrip(
 read_add_partitions_to_txn_result: Final = entity_reader(AddPartitionsToTxnResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnResult))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_result_roundtrip(
@@ -72,6 +76,7 @@ def test_add_partitions_to_txn_result_roundtrip(
 read_add_partitions_to_txn_response: Final = entity_reader(AddPartitionsToTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AddPartitionsToTxnResponse))
 @settings(max_examples=1)
 def test_add_partitions_to_txn_response_roundtrip(
@@ -85,6 +90,7 @@ def test_add_partitions_to_txn_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AddPartitionsToTxnResponse))
 def test_add_partitions_to_txn_response_java(
     instance: AddPartitionsToTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_allocate_producer_ids_v0_request.py
+++ b/tests/generated/test_allocate_producer_ids_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_allocate_producer_ids_request: Final = entity_reader(AllocateProducerIdsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AllocateProducerIdsRequest))
 @settings(max_examples=1)
 def test_allocate_producer_ids_request_roundtrip(
@@ -28,6 +30,7 @@ def test_allocate_producer_ids_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AllocateProducerIdsRequest))
 def test_allocate_producer_ids_request_java(
     instance: AllocateProducerIdsRequest, java_tester: JavaTester

--- a/tests/generated/test_allocate_producer_ids_v0_response.py
+++ b/tests/generated/test_allocate_producer_ids_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_allocate_producer_ids_response: Final = entity_reader(AllocateProducerIdsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AllocateProducerIdsResponse))
 @settings(max_examples=1)
 def test_allocate_producer_ids_response_roundtrip(
@@ -28,6 +30,7 @@ def test_allocate_producer_ids_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AllocateProducerIdsResponse))
 def test_allocate_producer_ids_response_java(
     instance: AllocateProducerIdsResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_client_quotas_v0_request.py
+++ b/tests/generated/test_alter_client_quotas_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_entity_data: Final = entity_reader(EntityData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntityData))
 @settings(max_examples=1)
 def test_entity_data_roundtrip(instance: EntityData) -> None:
@@ -32,6 +34,7 @@ def test_entity_data_roundtrip(instance: EntityData) -> None:
 read_op_data: Final = entity_reader(OpData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OpData))
 @settings(max_examples=1)
 def test_op_data_roundtrip(instance: OpData) -> None:
@@ -46,6 +49,7 @@ def test_op_data_roundtrip(instance: OpData) -> None:
 read_entry_data: Final = entity_reader(EntryData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntryData))
 @settings(max_examples=1)
 def test_entry_data_roundtrip(instance: EntryData) -> None:
@@ -60,6 +64,7 @@ def test_entry_data_roundtrip(instance: EntryData) -> None:
 read_alter_client_quotas_request: Final = entity_reader(AlterClientQuotasRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterClientQuotasRequest))
 @settings(max_examples=1)
 def test_alter_client_quotas_request_roundtrip(
@@ -73,6 +78,7 @@ def test_alter_client_quotas_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterClientQuotasRequest))
 def test_alter_client_quotas_request_java(
     instance: AlterClientQuotasRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_client_quotas_v0_response.py
+++ b/tests/generated/test_alter_client_quotas_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_entity_data: Final = entity_reader(EntityData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntityData))
 @settings(max_examples=1)
 def test_entity_data_roundtrip(instance: EntityData) -> None:
@@ -31,6 +33,7 @@ def test_entity_data_roundtrip(instance: EntityData) -> None:
 read_entry_data: Final = entity_reader(EntryData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntryData))
 @settings(max_examples=1)
 def test_entry_data_roundtrip(instance: EntryData) -> None:
@@ -45,6 +48,7 @@ def test_entry_data_roundtrip(instance: EntryData) -> None:
 read_alter_client_quotas_response: Final = entity_reader(AlterClientQuotasResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterClientQuotasResponse))
 @settings(max_examples=1)
 def test_alter_client_quotas_response_roundtrip(
@@ -58,6 +62,7 @@ def test_alter_client_quotas_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterClientQuotasResponse))
 def test_alter_client_quotas_response_java(
     instance: AlterClientQuotasResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_client_quotas_v1_request.py
+++ b/tests/generated/test_alter_client_quotas_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_entity_data: Final = entity_reader(EntityData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntityData))
 @settings(max_examples=1)
 def test_entity_data_roundtrip(instance: EntityData) -> None:
@@ -32,6 +34,7 @@ def test_entity_data_roundtrip(instance: EntityData) -> None:
 read_op_data: Final = entity_reader(OpData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OpData))
 @settings(max_examples=1)
 def test_op_data_roundtrip(instance: OpData) -> None:
@@ -46,6 +49,7 @@ def test_op_data_roundtrip(instance: OpData) -> None:
 read_entry_data: Final = entity_reader(EntryData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntryData))
 @settings(max_examples=1)
 def test_entry_data_roundtrip(instance: EntryData) -> None:
@@ -60,6 +64,7 @@ def test_entry_data_roundtrip(instance: EntryData) -> None:
 read_alter_client_quotas_request: Final = entity_reader(AlterClientQuotasRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterClientQuotasRequest))
 @settings(max_examples=1)
 def test_alter_client_quotas_request_roundtrip(
@@ -73,6 +78,7 @@ def test_alter_client_quotas_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterClientQuotasRequest))
 def test_alter_client_quotas_request_java(
     instance: AlterClientQuotasRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_client_quotas_v1_response.py
+++ b/tests/generated/test_alter_client_quotas_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_entity_data: Final = entity_reader(EntityData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntityData))
 @settings(max_examples=1)
 def test_entity_data_roundtrip(instance: EntityData) -> None:
@@ -31,6 +33,7 @@ def test_entity_data_roundtrip(instance: EntityData) -> None:
 read_entry_data: Final = entity_reader(EntryData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntryData))
 @settings(max_examples=1)
 def test_entry_data_roundtrip(instance: EntryData) -> None:
@@ -45,6 +48,7 @@ def test_entry_data_roundtrip(instance: EntryData) -> None:
 read_alter_client_quotas_response: Final = entity_reader(AlterClientQuotasResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterClientQuotasResponse))
 @settings(max_examples=1)
 def test_alter_client_quotas_response_roundtrip(
@@ -58,6 +62,7 @@ def test_alter_client_quotas_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterClientQuotasResponse))
 def test_alter_client_quotas_response_java(
     instance: AlterClientQuotasResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_configs_v0_request.py
+++ b/tests/generated/test_alter_configs_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_alterable_config: Final = entity_reader(AlterableConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterableConfig))
 @settings(max_examples=1)
 def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
@@ -31,6 +33,7 @@ def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
 read_alter_configs_resource: Final = entity_reader(AlterConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResource))
 @settings(max_examples=1)
 def test_alter_configs_resource_roundtrip(instance: AlterConfigsResource) -> None:
@@ -45,6 +48,7 @@ def test_alter_configs_resource_roundtrip(instance: AlterConfigsResource) -> Non
 read_alter_configs_request: Final = entity_reader(AlterConfigsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsRequest))
 @settings(max_examples=1)
 def test_alter_configs_request_roundtrip(instance: AlterConfigsRequest) -> None:
@@ -56,6 +60,7 @@ def test_alter_configs_request_roundtrip(instance: AlterConfigsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterConfigsRequest))
 def test_alter_configs_request_java(
     instance: AlterConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_configs_v0_response.py
+++ b/tests/generated/test_alter_configs_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ read_alter_configs_resource_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResourceResponse))
 @settings(max_examples=1)
 def test_alter_configs_resource_response_roundtrip(
@@ -34,6 +36,7 @@ def test_alter_configs_resource_response_roundtrip(
 read_alter_configs_response: Final = entity_reader(AlterConfigsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResponse))
 @settings(max_examples=1)
 def test_alter_configs_response_roundtrip(instance: AlterConfigsResponse) -> None:
@@ -45,6 +48,7 @@ def test_alter_configs_response_roundtrip(instance: AlterConfigsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterConfigsResponse))
 def test_alter_configs_response_java(
     instance: AlterConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_configs_v1_request.py
+++ b/tests/generated/test_alter_configs_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_alterable_config: Final = entity_reader(AlterableConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterableConfig))
 @settings(max_examples=1)
 def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
@@ -31,6 +33,7 @@ def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
 read_alter_configs_resource: Final = entity_reader(AlterConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResource))
 @settings(max_examples=1)
 def test_alter_configs_resource_roundtrip(instance: AlterConfigsResource) -> None:
@@ -45,6 +48,7 @@ def test_alter_configs_resource_roundtrip(instance: AlterConfigsResource) -> Non
 read_alter_configs_request: Final = entity_reader(AlterConfigsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsRequest))
 @settings(max_examples=1)
 def test_alter_configs_request_roundtrip(instance: AlterConfigsRequest) -> None:
@@ -56,6 +60,7 @@ def test_alter_configs_request_roundtrip(instance: AlterConfigsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterConfigsRequest))
 def test_alter_configs_request_java(
     instance: AlterConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_configs_v1_response.py
+++ b/tests/generated/test_alter_configs_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ read_alter_configs_resource_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResourceResponse))
 @settings(max_examples=1)
 def test_alter_configs_resource_response_roundtrip(
@@ -34,6 +36,7 @@ def test_alter_configs_resource_response_roundtrip(
 read_alter_configs_response: Final = entity_reader(AlterConfigsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResponse))
 @settings(max_examples=1)
 def test_alter_configs_response_roundtrip(instance: AlterConfigsResponse) -> None:
@@ -45,6 +48,7 @@ def test_alter_configs_response_roundtrip(instance: AlterConfigsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterConfigsResponse))
 def test_alter_configs_response_java(
     instance: AlterConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_configs_v2_request.py
+++ b/tests/generated/test_alter_configs_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_alterable_config: Final = entity_reader(AlterableConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterableConfig))
 @settings(max_examples=1)
 def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
@@ -31,6 +33,7 @@ def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
 read_alter_configs_resource: Final = entity_reader(AlterConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResource))
 @settings(max_examples=1)
 def test_alter_configs_resource_roundtrip(instance: AlterConfigsResource) -> None:
@@ -45,6 +48,7 @@ def test_alter_configs_resource_roundtrip(instance: AlterConfigsResource) -> Non
 read_alter_configs_request: Final = entity_reader(AlterConfigsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsRequest))
 @settings(max_examples=1)
 def test_alter_configs_request_roundtrip(instance: AlterConfigsRequest) -> None:
@@ -56,6 +60,7 @@ def test_alter_configs_request_roundtrip(instance: AlterConfigsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterConfigsRequest))
 def test_alter_configs_request_java(
     instance: AlterConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_configs_v2_response.py
+++ b/tests/generated/test_alter_configs_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ read_alter_configs_resource_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResourceResponse))
 @settings(max_examples=1)
 def test_alter_configs_resource_response_roundtrip(
@@ -34,6 +36,7 @@ def test_alter_configs_resource_response_roundtrip(
 read_alter_configs_response: Final = entity_reader(AlterConfigsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResponse))
 @settings(max_examples=1)
 def test_alter_configs_response_roundtrip(instance: AlterConfigsResponse) -> None:
@@ -45,6 +48,7 @@ def test_alter_configs_response_roundtrip(instance: AlterConfigsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterConfigsResponse))
 def test_alter_configs_response_java(
     instance: AlterConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_reassignments_v0_request.py
+++ b/tests/generated/test_alter_partition_reassignments_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ from tests.conftest import setup_buffer
 read_reassignable_partition: Final = entity_reader(ReassignablePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReassignablePartition))
 @settings(max_examples=1)
 def test_reassignable_partition_roundtrip(instance: ReassignablePartition) -> None:
@@ -33,6 +35,7 @@ def test_reassignable_partition_roundtrip(instance: ReassignablePartition) -> No
 read_reassignable_topic: Final = entity_reader(ReassignableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReassignableTopic))
 @settings(max_examples=1)
 def test_reassignable_topic_roundtrip(instance: ReassignableTopic) -> None:
@@ -49,6 +52,7 @@ read_alter_partition_reassignments_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionReassignmentsRequest))
 @settings(max_examples=1)
 def test_alter_partition_reassignments_request_roundtrip(
@@ -62,6 +66,7 @@ def test_alter_partition_reassignments_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionReassignmentsRequest))
 def test_alter_partition_reassignments_request_java(
     instance: AlterPartitionReassignmentsRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_reassignments_v0_response.py
+++ b/tests/generated/test_alter_partition_reassignments_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -25,6 +26,7 @@ read_reassignable_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReassignablePartitionResponse))
 @settings(max_examples=1)
 def test_reassignable_partition_response_roundtrip(
@@ -41,6 +43,7 @@ def test_reassignable_partition_response_roundtrip(
 read_reassignable_topic_response: Final = entity_reader(ReassignableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReassignableTopicResponse))
 @settings(max_examples=1)
 def test_reassignable_topic_response_roundtrip(
@@ -59,6 +62,7 @@ read_alter_partition_reassignments_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionReassignmentsResponse))
 @settings(max_examples=1)
 def test_alter_partition_reassignments_response_roundtrip(
@@ -72,6 +76,7 @@ def test_alter_partition_reassignments_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionReassignmentsResponse))
 def test_alter_partition_reassignments_response_java(
     instance: AlterPartitionReassignmentsResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_v0_request.py
+++ b/tests/generated/test_alter_partition_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_alter_partition_request: Final = entity_reader(AlterPartitionRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionRequest))
 @settings(max_examples=1)
 def test_alter_partition_request_roundtrip(instance: AlterPartitionRequest) -> None:
@@ -56,6 +60,7 @@ def test_alter_partition_request_roundtrip(instance: AlterPartitionRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionRequest))
 def test_alter_partition_request_java(
     instance: AlterPartitionRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_v0_response.py
+++ b/tests/generated/test_alter_partition_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_alter_partition_response: Final = entity_reader(AlterPartitionResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionResponse))
 @settings(max_examples=1)
 def test_alter_partition_response_roundtrip(instance: AlterPartitionResponse) -> None:
@@ -56,6 +60,7 @@ def test_alter_partition_response_roundtrip(instance: AlterPartitionResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionResponse))
 def test_alter_partition_response_java(
     instance: AlterPartitionResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_v1_request.py
+++ b/tests/generated/test_alter_partition_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_alter_partition_request: Final = entity_reader(AlterPartitionRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionRequest))
 @settings(max_examples=1)
 def test_alter_partition_request_roundtrip(instance: AlterPartitionRequest) -> None:
@@ -56,6 +60,7 @@ def test_alter_partition_request_roundtrip(instance: AlterPartitionRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionRequest))
 def test_alter_partition_request_java(
     instance: AlterPartitionRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_v1_response.py
+++ b/tests/generated/test_alter_partition_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_alter_partition_response: Final = entity_reader(AlterPartitionResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionResponse))
 @settings(max_examples=1)
 def test_alter_partition_response_roundtrip(instance: AlterPartitionResponse) -> None:
@@ -56,6 +60,7 @@ def test_alter_partition_response_roundtrip(instance: AlterPartitionResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionResponse))
 def test_alter_partition_response_java(
     instance: AlterPartitionResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_v2_request.py
+++ b/tests/generated/test_alter_partition_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_alter_partition_request: Final = entity_reader(AlterPartitionRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionRequest))
 @settings(max_examples=1)
 def test_alter_partition_request_roundtrip(instance: AlterPartitionRequest) -> None:
@@ -56,6 +60,7 @@ def test_alter_partition_request_roundtrip(instance: AlterPartitionRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionRequest))
 def test_alter_partition_request_java(
     instance: AlterPartitionRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_v2_response.py
+++ b/tests/generated/test_alter_partition_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_alter_partition_response: Final = entity_reader(AlterPartitionResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionResponse))
 @settings(max_examples=1)
 def test_alter_partition_response_roundtrip(instance: AlterPartitionResponse) -> None:
@@ -56,6 +60,7 @@ def test_alter_partition_response_roundtrip(instance: AlterPartitionResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionResponse))
 def test_alter_partition_response_java(
     instance: AlterPartitionResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_v3_request.py
+++ b/tests/generated/test_alter_partition_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_broker_state: Final = entity_reader(BrokerState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BrokerState))
 @settings(max_examples=1)
 def test_broker_state_roundtrip(instance: BrokerState) -> None:
@@ -32,6 +34,7 @@ def test_broker_state_roundtrip(instance: BrokerState) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -46,6 +49,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -60,6 +64,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_alter_partition_request: Final = entity_reader(AlterPartitionRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionRequest))
 @settings(max_examples=1)
 def test_alter_partition_request_roundtrip(instance: AlterPartitionRequest) -> None:
@@ -71,6 +76,7 @@ def test_alter_partition_request_roundtrip(instance: AlterPartitionRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionRequest))
 def test_alter_partition_request_java(
     instance: AlterPartitionRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_partition_v3_response.py
+++ b/tests/generated/test_alter_partition_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_alter_partition_response: Final = entity_reader(AlterPartitionResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterPartitionResponse))
 @settings(max_examples=1)
 def test_alter_partition_response_roundtrip(instance: AlterPartitionResponse) -> None:
@@ -56,6 +60,7 @@ def test_alter_partition_response_roundtrip(instance: AlterPartitionResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterPartitionResponse))
 def test_alter_partition_response_java(
     instance: AlterPartitionResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_replica_log_dirs_v0_request.py
+++ b/tests/generated/test_alter_replica_log_dirs_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_alter_replica_log_dir_topic: Final = entity_reader(AlterReplicaLogDirTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirTopic))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_topic_roundtrip(
@@ -33,6 +35,7 @@ def test_alter_replica_log_dir_topic_roundtrip(
 read_alter_replica_log_dir: Final = entity_reader(AlterReplicaLogDir)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDir))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_roundtrip(instance: AlterReplicaLogDir) -> None:
@@ -47,6 +50,7 @@ def test_alter_replica_log_dir_roundtrip(instance: AlterReplicaLogDir) -> None:
 read_alter_replica_log_dirs_request: Final = entity_reader(AlterReplicaLogDirsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirsRequest))
 @settings(max_examples=1)
 def test_alter_replica_log_dirs_request_roundtrip(
@@ -60,6 +64,7 @@ def test_alter_replica_log_dirs_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterReplicaLogDirsRequest))
 def test_alter_replica_log_dirs_request_java(
     instance: AlterReplicaLogDirsRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_replica_log_dirs_v0_response.py
+++ b/tests/generated/test_alter_replica_log_dirs_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_alter_replica_log_dir_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirPartitionResult))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_partition_result_roundtrip(
@@ -39,6 +41,7 @@ read_alter_replica_log_dir_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirTopicResult))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_topic_result_roundtrip(
@@ -55,6 +58,7 @@ def test_alter_replica_log_dir_topic_result_roundtrip(
 read_alter_replica_log_dirs_response: Final = entity_reader(AlterReplicaLogDirsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirsResponse))
 @settings(max_examples=1)
 def test_alter_replica_log_dirs_response_roundtrip(
@@ -68,6 +72,7 @@ def test_alter_replica_log_dirs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterReplicaLogDirsResponse))
 def test_alter_replica_log_dirs_response_java(
     instance: AlterReplicaLogDirsResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_replica_log_dirs_v1_request.py
+++ b/tests/generated/test_alter_replica_log_dirs_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_alter_replica_log_dir_topic: Final = entity_reader(AlterReplicaLogDirTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirTopic))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_topic_roundtrip(
@@ -33,6 +35,7 @@ def test_alter_replica_log_dir_topic_roundtrip(
 read_alter_replica_log_dir: Final = entity_reader(AlterReplicaLogDir)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDir))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_roundtrip(instance: AlterReplicaLogDir) -> None:
@@ -47,6 +50,7 @@ def test_alter_replica_log_dir_roundtrip(instance: AlterReplicaLogDir) -> None:
 read_alter_replica_log_dirs_request: Final = entity_reader(AlterReplicaLogDirsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirsRequest))
 @settings(max_examples=1)
 def test_alter_replica_log_dirs_request_roundtrip(
@@ -60,6 +64,7 @@ def test_alter_replica_log_dirs_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterReplicaLogDirsRequest))
 def test_alter_replica_log_dirs_request_java(
     instance: AlterReplicaLogDirsRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_replica_log_dirs_v1_response.py
+++ b/tests/generated/test_alter_replica_log_dirs_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_alter_replica_log_dir_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirPartitionResult))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_partition_result_roundtrip(
@@ -39,6 +41,7 @@ read_alter_replica_log_dir_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirTopicResult))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_topic_result_roundtrip(
@@ -55,6 +58,7 @@ def test_alter_replica_log_dir_topic_result_roundtrip(
 read_alter_replica_log_dirs_response: Final = entity_reader(AlterReplicaLogDirsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirsResponse))
 @settings(max_examples=1)
 def test_alter_replica_log_dirs_response_roundtrip(
@@ -68,6 +72,7 @@ def test_alter_replica_log_dirs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterReplicaLogDirsResponse))
 def test_alter_replica_log_dirs_response_java(
     instance: AlterReplicaLogDirsResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_replica_log_dirs_v2_request.py
+++ b/tests/generated/test_alter_replica_log_dirs_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_alter_replica_log_dir_topic: Final = entity_reader(AlterReplicaLogDirTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirTopic))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_topic_roundtrip(
@@ -33,6 +35,7 @@ def test_alter_replica_log_dir_topic_roundtrip(
 read_alter_replica_log_dir: Final = entity_reader(AlterReplicaLogDir)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDir))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_roundtrip(instance: AlterReplicaLogDir) -> None:
@@ -47,6 +50,7 @@ def test_alter_replica_log_dir_roundtrip(instance: AlterReplicaLogDir) -> None:
 read_alter_replica_log_dirs_request: Final = entity_reader(AlterReplicaLogDirsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirsRequest))
 @settings(max_examples=1)
 def test_alter_replica_log_dirs_request_roundtrip(
@@ -60,6 +64,7 @@ def test_alter_replica_log_dirs_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterReplicaLogDirsRequest))
 def test_alter_replica_log_dirs_request_java(
     instance: AlterReplicaLogDirsRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_replica_log_dirs_v2_response.py
+++ b/tests/generated/test_alter_replica_log_dirs_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_alter_replica_log_dir_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirPartitionResult))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_partition_result_roundtrip(
@@ -39,6 +41,7 @@ read_alter_replica_log_dir_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirTopicResult))
 @settings(max_examples=1)
 def test_alter_replica_log_dir_topic_result_roundtrip(
@@ -55,6 +58,7 @@ def test_alter_replica_log_dir_topic_result_roundtrip(
 read_alter_replica_log_dirs_response: Final = entity_reader(AlterReplicaLogDirsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterReplicaLogDirsResponse))
 @settings(max_examples=1)
 def test_alter_replica_log_dirs_response_roundtrip(
@@ -68,6 +72,7 @@ def test_alter_replica_log_dirs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterReplicaLogDirsResponse))
 def test_alter_replica_log_dirs_response_java(
     instance: AlterReplicaLogDirsResponse, java_tester: JavaTester

--- a/tests/generated/test_alter_user_scram_credentials_v0_request.py
+++ b/tests/generated/test_alter_user_scram_credentials_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ from tests.conftest import setup_buffer
 read_scram_credential_deletion: Final = entity_reader(ScramCredentialDeletion)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ScramCredentialDeletion))
 @settings(max_examples=1)
 def test_scram_credential_deletion_roundtrip(instance: ScramCredentialDeletion) -> None:
@@ -33,6 +35,7 @@ def test_scram_credential_deletion_roundtrip(instance: ScramCredentialDeletion) 
 read_scram_credential_upsertion: Final = entity_reader(ScramCredentialUpsertion)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ScramCredentialUpsertion))
 @settings(max_examples=1)
 def test_scram_credential_upsertion_roundtrip(
@@ -51,6 +54,7 @@ read_alter_user_scram_credentials_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterUserScramCredentialsRequest))
 @settings(max_examples=1)
 def test_alter_user_scram_credentials_request_roundtrip(
@@ -64,6 +68,7 @@ def test_alter_user_scram_credentials_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterUserScramCredentialsRequest))
 def test_alter_user_scram_credentials_request_java(
     instance: AlterUserScramCredentialsRequest, java_tester: JavaTester

--- a/tests/generated/test_alter_user_scram_credentials_v0_response.py
+++ b/tests/generated/test_alter_user_scram_credentials_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -22,6 +23,7 @@ read_alter_user_scram_credentials_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterUserScramCredentialsResult))
 @settings(max_examples=1)
 def test_alter_user_scram_credentials_result_roundtrip(
@@ -40,6 +42,7 @@ read_alter_user_scram_credentials_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterUserScramCredentialsResponse))
 @settings(max_examples=1)
 def test_alter_user_scram_credentials_response_roundtrip(
@@ -53,6 +56,7 @@ def test_alter_user_scram_credentials_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(AlterUserScramCredentialsResponse))
 def test_alter_user_scram_credentials_response_java(
     instance: AlterUserScramCredentialsResponse, java_tester: JavaTester

--- a/tests/generated/test_api_versions_v0_request.py
+++ b/tests/generated/test_api_versions_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_api_versions_request: Final = entity_reader(ApiVersionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersionsRequest))
 @settings(max_examples=1)
 def test_api_versions_request_roundtrip(instance: ApiVersionsRequest) -> None:
@@ -26,6 +28,7 @@ def test_api_versions_request_roundtrip(instance: ApiVersionsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ApiVersionsRequest))
 def test_api_versions_request_java(
     instance: ApiVersionsRequest, java_tester: JavaTester

--- a/tests/generated/test_api_versions_v0_response.py
+++ b/tests/generated/test_api_versions_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_api_version: Final = entity_reader(ApiVersion)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersion))
 @settings(max_examples=1)
 def test_api_version_roundtrip(instance: ApiVersion) -> None:
@@ -30,6 +32,7 @@ def test_api_version_roundtrip(instance: ApiVersion) -> None:
 read_api_versions_response: Final = entity_reader(ApiVersionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersionsResponse))
 @settings(max_examples=1)
 def test_api_versions_response_roundtrip(instance: ApiVersionsResponse) -> None:
@@ -41,6 +44,7 @@ def test_api_versions_response_roundtrip(instance: ApiVersionsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ApiVersionsResponse))
 def test_api_versions_response_java(
     instance: ApiVersionsResponse, java_tester: JavaTester

--- a/tests/generated/test_api_versions_v1_request.py
+++ b/tests/generated/test_api_versions_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_api_versions_request: Final = entity_reader(ApiVersionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersionsRequest))
 @settings(max_examples=1)
 def test_api_versions_request_roundtrip(instance: ApiVersionsRequest) -> None:
@@ -26,6 +28,7 @@ def test_api_versions_request_roundtrip(instance: ApiVersionsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ApiVersionsRequest))
 def test_api_versions_request_java(
     instance: ApiVersionsRequest, java_tester: JavaTester

--- a/tests/generated/test_api_versions_v1_response.py
+++ b/tests/generated/test_api_versions_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_api_version: Final = entity_reader(ApiVersion)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersion))
 @settings(max_examples=1)
 def test_api_version_roundtrip(instance: ApiVersion) -> None:
@@ -30,6 +32,7 @@ def test_api_version_roundtrip(instance: ApiVersion) -> None:
 read_api_versions_response: Final = entity_reader(ApiVersionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersionsResponse))
 @settings(max_examples=1)
 def test_api_versions_response_roundtrip(instance: ApiVersionsResponse) -> None:
@@ -41,6 +44,7 @@ def test_api_versions_response_roundtrip(instance: ApiVersionsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ApiVersionsResponse))
 def test_api_versions_response_java(
     instance: ApiVersionsResponse, java_tester: JavaTester

--- a/tests/generated/test_api_versions_v2_request.py
+++ b/tests/generated/test_api_versions_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_api_versions_request: Final = entity_reader(ApiVersionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersionsRequest))
 @settings(max_examples=1)
 def test_api_versions_request_roundtrip(instance: ApiVersionsRequest) -> None:
@@ -26,6 +28,7 @@ def test_api_versions_request_roundtrip(instance: ApiVersionsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ApiVersionsRequest))
 def test_api_versions_request_java(
     instance: ApiVersionsRequest, java_tester: JavaTester

--- a/tests/generated/test_api_versions_v2_response.py
+++ b/tests/generated/test_api_versions_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_api_version: Final = entity_reader(ApiVersion)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersion))
 @settings(max_examples=1)
 def test_api_version_roundtrip(instance: ApiVersion) -> None:
@@ -30,6 +32,7 @@ def test_api_version_roundtrip(instance: ApiVersion) -> None:
 read_api_versions_response: Final = entity_reader(ApiVersionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersionsResponse))
 @settings(max_examples=1)
 def test_api_versions_response_roundtrip(instance: ApiVersionsResponse) -> None:
@@ -41,6 +44,7 @@ def test_api_versions_response_roundtrip(instance: ApiVersionsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ApiVersionsResponse))
 def test_api_versions_response_java(
     instance: ApiVersionsResponse, java_tester: JavaTester

--- a/tests/generated/test_api_versions_v3_request.py
+++ b/tests/generated/test_api_versions_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_api_versions_request: Final = entity_reader(ApiVersionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersionsRequest))
 @settings(max_examples=1)
 def test_api_versions_request_roundtrip(instance: ApiVersionsRequest) -> None:
@@ -26,6 +28,7 @@ def test_api_versions_request_roundtrip(instance: ApiVersionsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ApiVersionsRequest))
 def test_api_versions_request_java(
     instance: ApiVersionsRequest, java_tester: JavaTester

--- a/tests/generated/test_api_versions_v3_response.py
+++ b/tests/generated/test_api_versions_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_api_version: Final = entity_reader(ApiVersion)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersion))
 @settings(max_examples=1)
 def test_api_version_roundtrip(instance: ApiVersion) -> None:
@@ -32,6 +34,7 @@ def test_api_version_roundtrip(instance: ApiVersion) -> None:
 read_supported_feature_key: Final = entity_reader(SupportedFeatureKey)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SupportedFeatureKey))
 @settings(max_examples=1)
 def test_supported_feature_key_roundtrip(instance: SupportedFeatureKey) -> None:
@@ -46,6 +49,7 @@ def test_supported_feature_key_roundtrip(instance: SupportedFeatureKey) -> None:
 read_finalized_feature_key: Final = entity_reader(FinalizedFeatureKey)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FinalizedFeatureKey))
 @settings(max_examples=1)
 def test_finalized_feature_key_roundtrip(instance: FinalizedFeatureKey) -> None:
@@ -60,6 +64,7 @@ def test_finalized_feature_key_roundtrip(instance: FinalizedFeatureKey) -> None:
 read_api_versions_response: Final = entity_reader(ApiVersionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ApiVersionsResponse))
 @settings(max_examples=1)
 def test_api_versions_response_roundtrip(instance: ApiVersionsResponse) -> None:
@@ -71,6 +76,7 @@ def test_api_versions_response_roundtrip(instance: ApiVersionsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ApiVersionsResponse))
 def test_api_versions_response_java(
     instance: ApiVersionsResponse, java_tester: JavaTester

--- a/tests/generated/test_begin_quorum_epoch_v0_request.py
+++ b/tests/generated/test_begin_quorum_epoch_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_begin_quorum_epoch_request: Final = entity_reader(BeginQuorumEpochRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BeginQuorumEpochRequest))
 @settings(max_examples=1)
 def test_begin_quorum_epoch_request_roundtrip(
@@ -58,6 +62,7 @@ def test_begin_quorum_epoch_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(BeginQuorumEpochRequest))
 def test_begin_quorum_epoch_request_java(
     instance: BeginQuorumEpochRequest, java_tester: JavaTester

--- a/tests/generated/test_begin_quorum_epoch_v0_response.py
+++ b/tests/generated/test_begin_quorum_epoch_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_begin_quorum_epoch_response: Final = entity_reader(BeginQuorumEpochResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BeginQuorumEpochResponse))
 @settings(max_examples=1)
 def test_begin_quorum_epoch_response_roundtrip(
@@ -58,6 +62,7 @@ def test_begin_quorum_epoch_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(BeginQuorumEpochResponse))
 def test_begin_quorum_epoch_response_java(
     instance: BeginQuorumEpochResponse, java_tester: JavaTester

--- a/tests/generated/test_broker_heartbeat_v0_request.py
+++ b/tests/generated/test_broker_heartbeat_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_broker_heartbeat_request: Final = entity_reader(BrokerHeartbeatRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BrokerHeartbeatRequest))
 @settings(max_examples=1)
 def test_broker_heartbeat_request_roundtrip(instance: BrokerHeartbeatRequest) -> None:
@@ -26,6 +28,7 @@ def test_broker_heartbeat_request_roundtrip(instance: BrokerHeartbeatRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(BrokerHeartbeatRequest))
 def test_broker_heartbeat_request_java(
     instance: BrokerHeartbeatRequest, java_tester: JavaTester

--- a/tests/generated/test_broker_heartbeat_v0_response.py
+++ b/tests/generated/test_broker_heartbeat_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_broker_heartbeat_response: Final = entity_reader(BrokerHeartbeatResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BrokerHeartbeatResponse))
 @settings(max_examples=1)
 def test_broker_heartbeat_response_roundtrip(instance: BrokerHeartbeatResponse) -> None:
@@ -26,6 +28,7 @@ def test_broker_heartbeat_response_roundtrip(instance: BrokerHeartbeatResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(BrokerHeartbeatResponse))
 def test_broker_heartbeat_response_java(
     instance: BrokerHeartbeatResponse, java_tester: JavaTester

--- a/tests/generated/test_broker_registration_v0_request.py
+++ b/tests/generated/test_broker_registration_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_listener: Final = entity_reader(Listener)
 
 
+@pytest.mark.roundtrip
 @given(from_type(Listener))
 @settings(max_examples=1)
 def test_listener_roundtrip(instance: Listener) -> None:
@@ -31,6 +33,7 @@ def test_listener_roundtrip(instance: Listener) -> None:
 read_feature: Final = entity_reader(Feature)
 
 
+@pytest.mark.roundtrip
 @given(from_type(Feature))
 @settings(max_examples=1)
 def test_feature_roundtrip(instance: Feature) -> None:
@@ -45,6 +48,7 @@ def test_feature_roundtrip(instance: Feature) -> None:
 read_broker_registration_request: Final = entity_reader(BrokerRegistrationRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BrokerRegistrationRequest))
 @settings(max_examples=1)
 def test_broker_registration_request_roundtrip(
@@ -58,6 +62,7 @@ def test_broker_registration_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(BrokerRegistrationRequest))
 def test_broker_registration_request_java(
     instance: BrokerRegistrationRequest, java_tester: JavaTester

--- a/tests/generated/test_broker_registration_v0_response.py
+++ b/tests/generated/test_broker_registration_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_broker_registration_response: Final = entity_reader(BrokerRegistrationResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BrokerRegistrationResponse))
 @settings(max_examples=1)
 def test_broker_registration_response_roundtrip(
@@ -28,6 +30,7 @@ def test_broker_registration_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(BrokerRegistrationResponse))
 def test_broker_registration_response_java(
     instance: BrokerRegistrationResponse, java_tester: JavaTester

--- a/tests/generated/test_broker_registration_v1_request.py
+++ b/tests/generated/test_broker_registration_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_listener: Final = entity_reader(Listener)
 
 
+@pytest.mark.roundtrip
 @given(from_type(Listener))
 @settings(max_examples=1)
 def test_listener_roundtrip(instance: Listener) -> None:
@@ -31,6 +33,7 @@ def test_listener_roundtrip(instance: Listener) -> None:
 read_feature: Final = entity_reader(Feature)
 
 
+@pytest.mark.roundtrip
 @given(from_type(Feature))
 @settings(max_examples=1)
 def test_feature_roundtrip(instance: Feature) -> None:
@@ -45,6 +48,7 @@ def test_feature_roundtrip(instance: Feature) -> None:
 read_broker_registration_request: Final = entity_reader(BrokerRegistrationRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BrokerRegistrationRequest))
 @settings(max_examples=1)
 def test_broker_registration_request_roundtrip(
@@ -58,6 +62,7 @@ def test_broker_registration_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(BrokerRegistrationRequest))
 def test_broker_registration_request_java(
     instance: BrokerRegistrationRequest, java_tester: JavaTester

--- a/tests/generated/test_broker_registration_v1_response.py
+++ b/tests/generated/test_broker_registration_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_broker_registration_response: Final = entity_reader(BrokerRegistrationResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BrokerRegistrationResponse))
 @settings(max_examples=1)
 def test_broker_registration_response_roundtrip(
@@ -28,6 +30,7 @@ def test_broker_registration_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(BrokerRegistrationResponse))
 def test_broker_registration_response_java(
     instance: BrokerRegistrationResponse, java_tester: JavaTester

--- a/tests/generated/test_consumer_group_heartbeat_v0_request.py
+++ b/tests/generated/test_consumer_group_heartbeat_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_assignor: Final = entity_reader(Assignor)
 
 
+@pytest.mark.roundtrip
 @given(from_type(Assignor))
 @settings(max_examples=1)
 def test_assignor_roundtrip(instance: Assignor) -> None:
@@ -31,6 +33,7 @@ def test_assignor_roundtrip(instance: Assignor) -> None:
 read_topic_partitions: Final = entity_reader(TopicPartitions)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartitions))
 @settings(max_examples=1)
 def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
@@ -47,6 +50,7 @@ read_consumer_group_heartbeat_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerGroupHeartbeatRequest))
 @settings(max_examples=1)
 def test_consumer_group_heartbeat_request_roundtrip(
@@ -60,6 +64,7 @@ def test_consumer_group_heartbeat_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerGroupHeartbeatRequest))
 def test_consumer_group_heartbeat_request_java(
     instance: ConsumerGroupHeartbeatRequest, java_tester: JavaTester

--- a/tests/generated/test_consumer_group_heartbeat_v0_response.py
+++ b/tests/generated/test_consumer_group_heartbeat_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_topic_partitions: Final = entity_reader(TopicPartitions)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartitions))
 @settings(max_examples=1)
 def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
@@ -32,6 +34,7 @@ def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
 read_assignment: Final = entity_reader(Assignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(Assignment))
 @settings(max_examples=1)
 def test_assignment_roundtrip(instance: Assignment) -> None:
@@ -48,6 +51,7 @@ read_consumer_group_heartbeat_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerGroupHeartbeatResponse))
 @settings(max_examples=1)
 def test_consumer_group_heartbeat_response_roundtrip(

--- a/tests/generated/test_consumer_protocol_assignment_v0_data.py
+++ b/tests/generated/test_consumer_protocol_assignment_v0_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_topic_partition: Final = entity_reader(TopicPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartition))
 @settings(max_examples=1)
 def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
@@ -30,6 +32,7 @@ def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
 read_consumer_protocol_assignment: Final = entity_reader(ConsumerProtocolAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerProtocolAssignment))
 @settings(max_examples=1)
 def test_consumer_protocol_assignment_roundtrip(
@@ -43,6 +46,7 @@ def test_consumer_protocol_assignment_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerProtocolAssignment))
 def test_consumer_protocol_assignment_java(
     instance: ConsumerProtocolAssignment, java_tester: JavaTester

--- a/tests/generated/test_consumer_protocol_assignment_v1_data.py
+++ b/tests/generated/test_consumer_protocol_assignment_v1_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_topic_partition: Final = entity_reader(TopicPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartition))
 @settings(max_examples=1)
 def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
@@ -30,6 +32,7 @@ def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
 read_consumer_protocol_assignment: Final = entity_reader(ConsumerProtocolAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerProtocolAssignment))
 @settings(max_examples=1)
 def test_consumer_protocol_assignment_roundtrip(
@@ -43,6 +46,7 @@ def test_consumer_protocol_assignment_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerProtocolAssignment))
 def test_consumer_protocol_assignment_java(
     instance: ConsumerProtocolAssignment, java_tester: JavaTester

--- a/tests/generated/test_consumer_protocol_assignment_v2_data.py
+++ b/tests/generated/test_consumer_protocol_assignment_v2_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_topic_partition: Final = entity_reader(TopicPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartition))
 @settings(max_examples=1)
 def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
@@ -30,6 +32,7 @@ def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
 read_consumer_protocol_assignment: Final = entity_reader(ConsumerProtocolAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerProtocolAssignment))
 @settings(max_examples=1)
 def test_consumer_protocol_assignment_roundtrip(
@@ -43,6 +46,7 @@ def test_consumer_protocol_assignment_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerProtocolAssignment))
 def test_consumer_protocol_assignment_java(
     instance: ConsumerProtocolAssignment, java_tester: JavaTester

--- a/tests/generated/test_consumer_protocol_assignment_v3_data.py
+++ b/tests/generated/test_consumer_protocol_assignment_v3_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_topic_partition: Final = entity_reader(TopicPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartition))
 @settings(max_examples=1)
 def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
@@ -30,6 +32,7 @@ def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
 read_consumer_protocol_assignment: Final = entity_reader(ConsumerProtocolAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerProtocolAssignment))
 @settings(max_examples=1)
 def test_consumer_protocol_assignment_roundtrip(
@@ -43,6 +46,7 @@ def test_consumer_protocol_assignment_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerProtocolAssignment))
 def test_consumer_protocol_assignment_java(
     instance: ConsumerProtocolAssignment, java_tester: JavaTester

--- a/tests/generated/test_consumer_protocol_subscription_v0_data.py
+++ b/tests/generated/test_consumer_protocol_subscription_v0_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_consumer_protocol_subscription: Final = entity_reader(ConsumerProtocolSubscription)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerProtocolSubscription))
 @settings(max_examples=1)
 def test_consumer_protocol_subscription_roundtrip(
@@ -30,6 +32,7 @@ def test_consumer_protocol_subscription_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerProtocolSubscription))
 def test_consumer_protocol_subscription_java(
     instance: ConsumerProtocolSubscription, java_tester: JavaTester

--- a/tests/generated/test_consumer_protocol_subscription_v1_data.py
+++ b/tests/generated/test_consumer_protocol_subscription_v1_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_topic_partition: Final = entity_reader(TopicPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartition))
 @settings(max_examples=1)
 def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
@@ -32,6 +34,7 @@ def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
 read_consumer_protocol_subscription: Final = entity_reader(ConsumerProtocolSubscription)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerProtocolSubscription))
 @settings(max_examples=1)
 def test_consumer_protocol_subscription_roundtrip(
@@ -45,6 +48,7 @@ def test_consumer_protocol_subscription_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerProtocolSubscription))
 def test_consumer_protocol_subscription_java(
     instance: ConsumerProtocolSubscription, java_tester: JavaTester

--- a/tests/generated/test_consumer_protocol_subscription_v2_data.py
+++ b/tests/generated/test_consumer_protocol_subscription_v2_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_topic_partition: Final = entity_reader(TopicPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartition))
 @settings(max_examples=1)
 def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
@@ -32,6 +34,7 @@ def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
 read_consumer_protocol_subscription: Final = entity_reader(ConsumerProtocolSubscription)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerProtocolSubscription))
 @settings(max_examples=1)
 def test_consumer_protocol_subscription_roundtrip(
@@ -45,6 +48,7 @@ def test_consumer_protocol_subscription_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerProtocolSubscription))
 def test_consumer_protocol_subscription_java(
     instance: ConsumerProtocolSubscription, java_tester: JavaTester

--- a/tests/generated/test_consumer_protocol_subscription_v3_data.py
+++ b/tests/generated/test_consumer_protocol_subscription_v3_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_topic_partition: Final = entity_reader(TopicPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartition))
 @settings(max_examples=1)
 def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
@@ -32,6 +34,7 @@ def test_topic_partition_roundtrip(instance: TopicPartition) -> None:
 read_consumer_protocol_subscription: Final = entity_reader(ConsumerProtocolSubscription)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ConsumerProtocolSubscription))
 @settings(max_examples=1)
 def test_consumer_protocol_subscription_roundtrip(
@@ -45,6 +48,7 @@ def test_consumer_protocol_subscription_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ConsumerProtocolSubscription))
 def test_consumer_protocol_subscription_java(
     instance: ConsumerProtocolSubscription, java_tester: JavaTester

--- a/tests/generated/test_controlled_shutdown_v0_request.py
+++ b/tests/generated/test_controlled_shutdown_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_controlled_shutdown_request: Final = entity_reader(ControlledShutdownRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ControlledShutdownRequest))
 @settings(max_examples=1)
 def test_controlled_shutdown_request_roundtrip(
@@ -28,6 +30,7 @@ def test_controlled_shutdown_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ControlledShutdownRequest))
 def test_controlled_shutdown_request_java(
     instance: ControlledShutdownRequest, java_tester: JavaTester

--- a/tests/generated/test_controlled_shutdown_v0_response.py
+++ b/tests/generated/test_controlled_shutdown_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_remaining_partition: Final = entity_reader(RemainingPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RemainingPartition))
 @settings(max_examples=1)
 def test_remaining_partition_roundtrip(instance: RemainingPartition) -> None:
@@ -30,6 +32,7 @@ def test_remaining_partition_roundtrip(instance: RemainingPartition) -> None:
 read_controlled_shutdown_response: Final = entity_reader(ControlledShutdownResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ControlledShutdownResponse))
 @settings(max_examples=1)
 def test_controlled_shutdown_response_roundtrip(
@@ -43,6 +46,7 @@ def test_controlled_shutdown_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ControlledShutdownResponse))
 def test_controlled_shutdown_response_java(
     instance: ControlledShutdownResponse, java_tester: JavaTester

--- a/tests/generated/test_controlled_shutdown_v1_request.py
+++ b/tests/generated/test_controlled_shutdown_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_controlled_shutdown_request: Final = entity_reader(ControlledShutdownRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ControlledShutdownRequest))
 @settings(max_examples=1)
 def test_controlled_shutdown_request_roundtrip(
@@ -28,6 +30,7 @@ def test_controlled_shutdown_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ControlledShutdownRequest))
 def test_controlled_shutdown_request_java(
     instance: ControlledShutdownRequest, java_tester: JavaTester

--- a/tests/generated/test_controlled_shutdown_v1_response.py
+++ b/tests/generated/test_controlled_shutdown_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_remaining_partition: Final = entity_reader(RemainingPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RemainingPartition))
 @settings(max_examples=1)
 def test_remaining_partition_roundtrip(instance: RemainingPartition) -> None:
@@ -30,6 +32,7 @@ def test_remaining_partition_roundtrip(instance: RemainingPartition) -> None:
 read_controlled_shutdown_response: Final = entity_reader(ControlledShutdownResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ControlledShutdownResponse))
 @settings(max_examples=1)
 def test_controlled_shutdown_response_roundtrip(
@@ -43,6 +46,7 @@ def test_controlled_shutdown_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ControlledShutdownResponse))
 def test_controlled_shutdown_response_java(
     instance: ControlledShutdownResponse, java_tester: JavaTester

--- a/tests/generated/test_controlled_shutdown_v2_request.py
+++ b/tests/generated/test_controlled_shutdown_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_controlled_shutdown_request: Final = entity_reader(ControlledShutdownRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ControlledShutdownRequest))
 @settings(max_examples=1)
 def test_controlled_shutdown_request_roundtrip(
@@ -28,6 +30,7 @@ def test_controlled_shutdown_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ControlledShutdownRequest))
 def test_controlled_shutdown_request_java(
     instance: ControlledShutdownRequest, java_tester: JavaTester

--- a/tests/generated/test_controlled_shutdown_v2_response.py
+++ b/tests/generated/test_controlled_shutdown_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_remaining_partition: Final = entity_reader(RemainingPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RemainingPartition))
 @settings(max_examples=1)
 def test_remaining_partition_roundtrip(instance: RemainingPartition) -> None:
@@ -30,6 +32,7 @@ def test_remaining_partition_roundtrip(instance: RemainingPartition) -> None:
 read_controlled_shutdown_response: Final = entity_reader(ControlledShutdownResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ControlledShutdownResponse))
 @settings(max_examples=1)
 def test_controlled_shutdown_response_roundtrip(
@@ -43,6 +46,7 @@ def test_controlled_shutdown_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ControlledShutdownResponse))
 def test_controlled_shutdown_response_java(
     instance: ControlledShutdownResponse, java_tester: JavaTester

--- a/tests/generated/test_controlled_shutdown_v3_request.py
+++ b/tests/generated/test_controlled_shutdown_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_controlled_shutdown_request: Final = entity_reader(ControlledShutdownRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ControlledShutdownRequest))
 @settings(max_examples=1)
 def test_controlled_shutdown_request_roundtrip(
@@ -28,6 +30,7 @@ def test_controlled_shutdown_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ControlledShutdownRequest))
 def test_controlled_shutdown_request_java(
     instance: ControlledShutdownRequest, java_tester: JavaTester

--- a/tests/generated/test_controlled_shutdown_v3_response.py
+++ b/tests/generated/test_controlled_shutdown_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_remaining_partition: Final = entity_reader(RemainingPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RemainingPartition))
 @settings(max_examples=1)
 def test_remaining_partition_roundtrip(instance: RemainingPartition) -> None:
@@ -30,6 +32,7 @@ def test_remaining_partition_roundtrip(instance: RemainingPartition) -> None:
 read_controlled_shutdown_response: Final = entity_reader(ControlledShutdownResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ControlledShutdownResponse))
 @settings(max_examples=1)
 def test_controlled_shutdown_response_roundtrip(
@@ -43,6 +46,7 @@ def test_controlled_shutdown_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ControlledShutdownResponse))
 def test_controlled_shutdown_response_java(
     instance: ControlledShutdownResponse, java_tester: JavaTester

--- a/tests/generated/test_create_acls_v0_request.py
+++ b/tests/generated/test_create_acls_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_acl_creation: Final = entity_reader(AclCreation)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclCreation))
 @settings(max_examples=1)
 def test_acl_creation_roundtrip(instance: AclCreation) -> None:
@@ -30,6 +32,7 @@ def test_acl_creation_roundtrip(instance: AclCreation) -> None:
 read_create_acls_request: Final = entity_reader(CreateAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateAclsRequest))
 @settings(max_examples=1)
 def test_create_acls_request_roundtrip(instance: CreateAclsRequest) -> None:
@@ -41,6 +44,7 @@ def test_create_acls_request_roundtrip(instance: CreateAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateAclsRequest))
 def test_create_acls_request_java(
     instance: CreateAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_acls_v0_response.py
+++ b/tests/generated/test_create_acls_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_acl_creation_result: Final = entity_reader(AclCreationResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclCreationResult))
 @settings(max_examples=1)
 def test_acl_creation_result_roundtrip(instance: AclCreationResult) -> None:
@@ -30,6 +32,7 @@ def test_acl_creation_result_roundtrip(instance: AclCreationResult) -> None:
 read_create_acls_response: Final = entity_reader(CreateAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateAclsResponse))
 @settings(max_examples=1)
 def test_create_acls_response_roundtrip(instance: CreateAclsResponse) -> None:
@@ -41,6 +44,7 @@ def test_create_acls_response_roundtrip(instance: CreateAclsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateAclsResponse))
 def test_create_acls_response_java(
     instance: CreateAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_create_acls_v1_request.py
+++ b/tests/generated/test_create_acls_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_acl_creation: Final = entity_reader(AclCreation)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclCreation))
 @settings(max_examples=1)
 def test_acl_creation_roundtrip(instance: AclCreation) -> None:
@@ -30,6 +32,7 @@ def test_acl_creation_roundtrip(instance: AclCreation) -> None:
 read_create_acls_request: Final = entity_reader(CreateAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateAclsRequest))
 @settings(max_examples=1)
 def test_create_acls_request_roundtrip(instance: CreateAclsRequest) -> None:
@@ -41,6 +44,7 @@ def test_create_acls_request_roundtrip(instance: CreateAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateAclsRequest))
 def test_create_acls_request_java(
     instance: CreateAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_acls_v1_response.py
+++ b/tests/generated/test_create_acls_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_acl_creation_result: Final = entity_reader(AclCreationResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclCreationResult))
 @settings(max_examples=1)
 def test_acl_creation_result_roundtrip(instance: AclCreationResult) -> None:
@@ -30,6 +32,7 @@ def test_acl_creation_result_roundtrip(instance: AclCreationResult) -> None:
 read_create_acls_response: Final = entity_reader(CreateAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateAclsResponse))
 @settings(max_examples=1)
 def test_create_acls_response_roundtrip(instance: CreateAclsResponse) -> None:
@@ -41,6 +44,7 @@ def test_create_acls_response_roundtrip(instance: CreateAclsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateAclsResponse))
 def test_create_acls_response_java(
     instance: CreateAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_create_acls_v2_request.py
+++ b/tests/generated/test_create_acls_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_acl_creation: Final = entity_reader(AclCreation)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclCreation))
 @settings(max_examples=1)
 def test_acl_creation_roundtrip(instance: AclCreation) -> None:
@@ -30,6 +32,7 @@ def test_acl_creation_roundtrip(instance: AclCreation) -> None:
 read_create_acls_request: Final = entity_reader(CreateAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateAclsRequest))
 @settings(max_examples=1)
 def test_create_acls_request_roundtrip(instance: CreateAclsRequest) -> None:
@@ -41,6 +44,7 @@ def test_create_acls_request_roundtrip(instance: CreateAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateAclsRequest))
 def test_create_acls_request_java(
     instance: CreateAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_acls_v2_response.py
+++ b/tests/generated/test_create_acls_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_acl_creation_result: Final = entity_reader(AclCreationResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclCreationResult))
 @settings(max_examples=1)
 def test_acl_creation_result_roundtrip(instance: AclCreationResult) -> None:
@@ -30,6 +32,7 @@ def test_acl_creation_result_roundtrip(instance: AclCreationResult) -> None:
 read_create_acls_response: Final = entity_reader(CreateAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateAclsResponse))
 @settings(max_examples=1)
 def test_create_acls_response_roundtrip(instance: CreateAclsResponse) -> None:
@@ -41,6 +44,7 @@ def test_create_acls_response_roundtrip(instance: CreateAclsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateAclsResponse))
 def test_create_acls_response_java(
     instance: CreateAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_create_acls_v3_request.py
+++ b/tests/generated/test_create_acls_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_acl_creation: Final = entity_reader(AclCreation)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclCreation))
 @settings(max_examples=1)
 def test_acl_creation_roundtrip(instance: AclCreation) -> None:
@@ -30,6 +32,7 @@ def test_acl_creation_roundtrip(instance: AclCreation) -> None:
 read_create_acls_request: Final = entity_reader(CreateAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateAclsRequest))
 @settings(max_examples=1)
 def test_create_acls_request_roundtrip(instance: CreateAclsRequest) -> None:
@@ -41,6 +44,7 @@ def test_create_acls_request_roundtrip(instance: CreateAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateAclsRequest))
 def test_create_acls_request_java(
     instance: CreateAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_acls_v3_response.py
+++ b/tests/generated/test_create_acls_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_acl_creation_result: Final = entity_reader(AclCreationResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclCreationResult))
 @settings(max_examples=1)
 def test_acl_creation_result_roundtrip(instance: AclCreationResult) -> None:
@@ -30,6 +32,7 @@ def test_acl_creation_result_roundtrip(instance: AclCreationResult) -> None:
 read_create_acls_response: Final = entity_reader(CreateAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateAclsResponse))
 @settings(max_examples=1)
 def test_create_acls_response_roundtrip(instance: CreateAclsResponse) -> None:
@@ -41,6 +44,7 @@ def test_create_acls_response_roundtrip(instance: CreateAclsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateAclsResponse))
 def test_create_acls_response_java(
     instance: CreateAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_create_delegation_token_v0_request.py
+++ b/tests/generated/test_create_delegation_token_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_creatable_renewers: Final = entity_reader(CreatableRenewers)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableRenewers))
 @settings(max_examples=1)
 def test_creatable_renewers_roundtrip(instance: CreatableRenewers) -> None:
@@ -32,6 +34,7 @@ read_create_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateDelegationTokenRequest))
 @settings(max_examples=1)
 def test_create_delegation_token_request_roundtrip(
@@ -45,6 +48,7 @@ def test_create_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateDelegationTokenRequest))
 def test_create_delegation_token_request_java(
     instance: CreateDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_create_delegation_token_v0_response.py
+++ b/tests/generated/test_create_delegation_token_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_create_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateDelegationTokenResponse))
 @settings(max_examples=1)
 def test_create_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_create_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateDelegationTokenResponse))
 def test_create_delegation_token_response_java(
     instance: CreateDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_create_delegation_token_v1_request.py
+++ b/tests/generated/test_create_delegation_token_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_creatable_renewers: Final = entity_reader(CreatableRenewers)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableRenewers))
 @settings(max_examples=1)
 def test_creatable_renewers_roundtrip(instance: CreatableRenewers) -> None:
@@ -32,6 +34,7 @@ read_create_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateDelegationTokenRequest))
 @settings(max_examples=1)
 def test_create_delegation_token_request_roundtrip(
@@ -45,6 +48,7 @@ def test_create_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateDelegationTokenRequest))
 def test_create_delegation_token_request_java(
     instance: CreateDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_create_delegation_token_v1_response.py
+++ b/tests/generated/test_create_delegation_token_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_create_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateDelegationTokenResponse))
 @settings(max_examples=1)
 def test_create_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_create_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateDelegationTokenResponse))
 def test_create_delegation_token_response_java(
     instance: CreateDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_create_delegation_token_v2_request.py
+++ b/tests/generated/test_create_delegation_token_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_creatable_renewers: Final = entity_reader(CreatableRenewers)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableRenewers))
 @settings(max_examples=1)
 def test_creatable_renewers_roundtrip(instance: CreatableRenewers) -> None:
@@ -32,6 +34,7 @@ read_create_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateDelegationTokenRequest))
 @settings(max_examples=1)
 def test_create_delegation_token_request_roundtrip(
@@ -45,6 +48,7 @@ def test_create_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateDelegationTokenRequest))
 def test_create_delegation_token_request_java(
     instance: CreateDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_create_delegation_token_v2_response.py
+++ b/tests/generated/test_create_delegation_token_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_create_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateDelegationTokenResponse))
 @settings(max_examples=1)
 def test_create_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_create_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateDelegationTokenResponse))
 def test_create_delegation_token_response_java(
     instance: CreateDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_create_delegation_token_v3_request.py
+++ b/tests/generated/test_create_delegation_token_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_creatable_renewers: Final = entity_reader(CreatableRenewers)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableRenewers))
 @settings(max_examples=1)
 def test_creatable_renewers_roundtrip(instance: CreatableRenewers) -> None:
@@ -32,6 +34,7 @@ read_create_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateDelegationTokenRequest))
 @settings(max_examples=1)
 def test_create_delegation_token_request_roundtrip(
@@ -45,6 +48,7 @@ def test_create_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateDelegationTokenRequest))
 def test_create_delegation_token_request_java(
     instance: CreateDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_create_delegation_token_v3_response.py
+++ b/tests/generated/test_create_delegation_token_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_create_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateDelegationTokenResponse))
 @settings(max_examples=1)
 def test_create_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_create_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateDelegationTokenResponse))
 def test_create_delegation_token_response_java(
     instance: CreateDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_create_partitions_v0_request.py
+++ b/tests/generated/test_create_partitions_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_create_partitions_assignment: Final = entity_reader(CreatePartitionsAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsAssignment))
 @settings(max_examples=1)
 def test_create_partitions_assignment_roundtrip(
@@ -33,6 +35,7 @@ def test_create_partitions_assignment_roundtrip(
 read_create_partitions_topic: Final = entity_reader(CreatePartitionsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsTopic))
 @settings(max_examples=1)
 def test_create_partitions_topic_roundtrip(instance: CreatePartitionsTopic) -> None:
@@ -47,6 +50,7 @@ def test_create_partitions_topic_roundtrip(instance: CreatePartitionsTopic) -> N
 read_create_partitions_request: Final = entity_reader(CreatePartitionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsRequest))
 @settings(max_examples=1)
 def test_create_partitions_request_roundtrip(instance: CreatePartitionsRequest) -> None:
@@ -58,6 +62,7 @@ def test_create_partitions_request_roundtrip(instance: CreatePartitionsRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreatePartitionsRequest))
 def test_create_partitions_request_java(
     instance: CreatePartitionsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_partitions_v0_response.py
+++ b/tests/generated/test_create_partitions_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_create_partitions_topic_result: Final = entity_reader(CreatePartitionsTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsTopicResult))
 @settings(max_examples=1)
 def test_create_partitions_topic_result_roundtrip(
@@ -32,6 +34,7 @@ def test_create_partitions_topic_result_roundtrip(
 read_create_partitions_response: Final = entity_reader(CreatePartitionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsResponse))
 @settings(max_examples=1)
 def test_create_partitions_response_roundtrip(
@@ -45,6 +48,7 @@ def test_create_partitions_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreatePartitionsResponse))
 def test_create_partitions_response_java(
     instance: CreatePartitionsResponse, java_tester: JavaTester

--- a/tests/generated/test_create_partitions_v1_request.py
+++ b/tests/generated/test_create_partitions_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_create_partitions_assignment: Final = entity_reader(CreatePartitionsAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsAssignment))
 @settings(max_examples=1)
 def test_create_partitions_assignment_roundtrip(
@@ -33,6 +35,7 @@ def test_create_partitions_assignment_roundtrip(
 read_create_partitions_topic: Final = entity_reader(CreatePartitionsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsTopic))
 @settings(max_examples=1)
 def test_create_partitions_topic_roundtrip(instance: CreatePartitionsTopic) -> None:
@@ -47,6 +50,7 @@ def test_create_partitions_topic_roundtrip(instance: CreatePartitionsTopic) -> N
 read_create_partitions_request: Final = entity_reader(CreatePartitionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsRequest))
 @settings(max_examples=1)
 def test_create_partitions_request_roundtrip(instance: CreatePartitionsRequest) -> None:
@@ -58,6 +62,7 @@ def test_create_partitions_request_roundtrip(instance: CreatePartitionsRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreatePartitionsRequest))
 def test_create_partitions_request_java(
     instance: CreatePartitionsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_partitions_v1_response.py
+++ b/tests/generated/test_create_partitions_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_create_partitions_topic_result: Final = entity_reader(CreatePartitionsTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsTopicResult))
 @settings(max_examples=1)
 def test_create_partitions_topic_result_roundtrip(
@@ -32,6 +34,7 @@ def test_create_partitions_topic_result_roundtrip(
 read_create_partitions_response: Final = entity_reader(CreatePartitionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsResponse))
 @settings(max_examples=1)
 def test_create_partitions_response_roundtrip(
@@ -45,6 +48,7 @@ def test_create_partitions_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreatePartitionsResponse))
 def test_create_partitions_response_java(
     instance: CreatePartitionsResponse, java_tester: JavaTester

--- a/tests/generated/test_create_partitions_v2_request.py
+++ b/tests/generated/test_create_partitions_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_create_partitions_assignment: Final = entity_reader(CreatePartitionsAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsAssignment))
 @settings(max_examples=1)
 def test_create_partitions_assignment_roundtrip(
@@ -33,6 +35,7 @@ def test_create_partitions_assignment_roundtrip(
 read_create_partitions_topic: Final = entity_reader(CreatePartitionsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsTopic))
 @settings(max_examples=1)
 def test_create_partitions_topic_roundtrip(instance: CreatePartitionsTopic) -> None:
@@ -47,6 +50,7 @@ def test_create_partitions_topic_roundtrip(instance: CreatePartitionsTopic) -> N
 read_create_partitions_request: Final = entity_reader(CreatePartitionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsRequest))
 @settings(max_examples=1)
 def test_create_partitions_request_roundtrip(instance: CreatePartitionsRequest) -> None:
@@ -58,6 +62,7 @@ def test_create_partitions_request_roundtrip(instance: CreatePartitionsRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreatePartitionsRequest))
 def test_create_partitions_request_java(
     instance: CreatePartitionsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_partitions_v2_response.py
+++ b/tests/generated/test_create_partitions_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_create_partitions_topic_result: Final = entity_reader(CreatePartitionsTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsTopicResult))
 @settings(max_examples=1)
 def test_create_partitions_topic_result_roundtrip(
@@ -32,6 +34,7 @@ def test_create_partitions_topic_result_roundtrip(
 read_create_partitions_response: Final = entity_reader(CreatePartitionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsResponse))
 @settings(max_examples=1)
 def test_create_partitions_response_roundtrip(
@@ -45,6 +48,7 @@ def test_create_partitions_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreatePartitionsResponse))
 def test_create_partitions_response_java(
     instance: CreatePartitionsResponse, java_tester: JavaTester

--- a/tests/generated/test_create_partitions_v3_request.py
+++ b/tests/generated/test_create_partitions_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_create_partitions_assignment: Final = entity_reader(CreatePartitionsAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsAssignment))
 @settings(max_examples=1)
 def test_create_partitions_assignment_roundtrip(
@@ -33,6 +35,7 @@ def test_create_partitions_assignment_roundtrip(
 read_create_partitions_topic: Final = entity_reader(CreatePartitionsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsTopic))
 @settings(max_examples=1)
 def test_create_partitions_topic_roundtrip(instance: CreatePartitionsTopic) -> None:
@@ -47,6 +50,7 @@ def test_create_partitions_topic_roundtrip(instance: CreatePartitionsTopic) -> N
 read_create_partitions_request: Final = entity_reader(CreatePartitionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsRequest))
 @settings(max_examples=1)
 def test_create_partitions_request_roundtrip(instance: CreatePartitionsRequest) -> None:
@@ -58,6 +62,7 @@ def test_create_partitions_request_roundtrip(instance: CreatePartitionsRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreatePartitionsRequest))
 def test_create_partitions_request_java(
     instance: CreatePartitionsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_partitions_v3_response.py
+++ b/tests/generated/test_create_partitions_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_create_partitions_topic_result: Final = entity_reader(CreatePartitionsTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsTopicResult))
 @settings(max_examples=1)
 def test_create_partitions_topic_result_roundtrip(
@@ -32,6 +34,7 @@ def test_create_partitions_topic_result_roundtrip(
 read_create_partitions_response: Final = entity_reader(CreatePartitionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatePartitionsResponse))
 @settings(max_examples=1)
 def test_create_partitions_response_roundtrip(
@@ -45,6 +48,7 @@ def test_create_partitions_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreatePartitionsResponse))
 def test_create_partitions_response_java(
     instance: CreatePartitionsResponse, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v0_request.py
+++ b/tests/generated/test_create_topics_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_creatable_replica_assignment: Final = entity_reader(CreatableReplicaAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableReplicaAssignment))
 @settings(max_examples=1)
 def test_creatable_replica_assignment_roundtrip(
@@ -34,6 +36,7 @@ def test_creatable_replica_assignment_roundtrip(
 read_createable_topic_config: Final = entity_reader(CreateableTopicConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateableTopicConfig))
 @settings(max_examples=1)
 def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> None:
@@ -48,6 +51,7 @@ def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> N
 read_creatable_topic: Final = entity_reader(CreatableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopic))
 @settings(max_examples=1)
 def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
@@ -62,6 +66,7 @@ def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
 read_create_topics_request: Final = entity_reader(CreateTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsRequest))
 @settings(max_examples=1)
 def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
@@ -73,6 +78,7 @@ def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateTopicsRequest))
 def test_create_topics_request_java(
     instance: CreateTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v0_response.py
+++ b/tests/generated/test_create_topics_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_creatable_topic_result: Final = entity_reader(CreatableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicResult))
 @settings(max_examples=1)
 def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> None:
@@ -29,6 +31,7 @@ def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> Non
 read_create_topics_response: Final = entity_reader(CreateTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsResponse))
 @settings(max_examples=1)
 def test_create_topics_response_roundtrip(instance: CreateTopicsResponse) -> None:

--- a/tests/generated/test_create_topics_v1_request.py
+++ b/tests/generated/test_create_topics_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_creatable_replica_assignment: Final = entity_reader(CreatableReplicaAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableReplicaAssignment))
 @settings(max_examples=1)
 def test_creatable_replica_assignment_roundtrip(
@@ -34,6 +36,7 @@ def test_creatable_replica_assignment_roundtrip(
 read_createable_topic_config: Final = entity_reader(CreateableTopicConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateableTopicConfig))
 @settings(max_examples=1)
 def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> None:
@@ -48,6 +51,7 @@ def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> N
 read_creatable_topic: Final = entity_reader(CreatableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopic))
 @settings(max_examples=1)
 def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
@@ -62,6 +66,7 @@ def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
 read_create_topics_request: Final = entity_reader(CreateTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsRequest))
 @settings(max_examples=1)
 def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
@@ -73,6 +78,7 @@ def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateTopicsRequest))
 def test_create_topics_request_java(
     instance: CreateTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v1_response.py
+++ b/tests/generated/test_create_topics_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_creatable_topic_result: Final = entity_reader(CreatableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicResult))
 @settings(max_examples=1)
 def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> None:
@@ -29,6 +31,7 @@ def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> Non
 read_create_topics_response: Final = entity_reader(CreateTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsResponse))
 @settings(max_examples=1)
 def test_create_topics_response_roundtrip(instance: CreateTopicsResponse) -> None:

--- a/tests/generated/test_create_topics_v2_request.py
+++ b/tests/generated/test_create_topics_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_creatable_replica_assignment: Final = entity_reader(CreatableReplicaAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableReplicaAssignment))
 @settings(max_examples=1)
 def test_creatable_replica_assignment_roundtrip(
@@ -34,6 +36,7 @@ def test_creatable_replica_assignment_roundtrip(
 read_createable_topic_config: Final = entity_reader(CreateableTopicConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateableTopicConfig))
 @settings(max_examples=1)
 def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> None:
@@ -48,6 +51,7 @@ def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> N
 read_creatable_topic: Final = entity_reader(CreatableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopic))
 @settings(max_examples=1)
 def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
@@ -62,6 +66,7 @@ def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
 read_create_topics_request: Final = entity_reader(CreateTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsRequest))
 @settings(max_examples=1)
 def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
@@ -73,6 +78,7 @@ def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateTopicsRequest))
 def test_create_topics_request_java(
     instance: CreateTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v2_response.py
+++ b/tests/generated/test_create_topics_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_creatable_topic_result: Final = entity_reader(CreatableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicResult))
 @settings(max_examples=1)
 def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> None:
@@ -29,6 +31,7 @@ def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> Non
 read_create_topics_response: Final = entity_reader(CreateTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsResponse))
 @settings(max_examples=1)
 def test_create_topics_response_roundtrip(instance: CreateTopicsResponse) -> None:

--- a/tests/generated/test_create_topics_v3_request.py
+++ b/tests/generated/test_create_topics_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_creatable_replica_assignment: Final = entity_reader(CreatableReplicaAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableReplicaAssignment))
 @settings(max_examples=1)
 def test_creatable_replica_assignment_roundtrip(
@@ -34,6 +36,7 @@ def test_creatable_replica_assignment_roundtrip(
 read_createable_topic_config: Final = entity_reader(CreateableTopicConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateableTopicConfig))
 @settings(max_examples=1)
 def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> None:
@@ -48,6 +51,7 @@ def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> N
 read_creatable_topic: Final = entity_reader(CreatableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopic))
 @settings(max_examples=1)
 def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
@@ -62,6 +66,7 @@ def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
 read_create_topics_request: Final = entity_reader(CreateTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsRequest))
 @settings(max_examples=1)
 def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
@@ -73,6 +78,7 @@ def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateTopicsRequest))
 def test_create_topics_request_java(
     instance: CreateTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v3_response.py
+++ b/tests/generated/test_create_topics_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_creatable_topic_result: Final = entity_reader(CreatableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicResult))
 @settings(max_examples=1)
 def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> None:
@@ -29,6 +31,7 @@ def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> Non
 read_create_topics_response: Final = entity_reader(CreateTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsResponse))
 @settings(max_examples=1)
 def test_create_topics_response_roundtrip(instance: CreateTopicsResponse) -> None:

--- a/tests/generated/test_create_topics_v4_request.py
+++ b/tests/generated/test_create_topics_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_creatable_replica_assignment: Final = entity_reader(CreatableReplicaAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableReplicaAssignment))
 @settings(max_examples=1)
 def test_creatable_replica_assignment_roundtrip(
@@ -34,6 +36,7 @@ def test_creatable_replica_assignment_roundtrip(
 read_createable_topic_config: Final = entity_reader(CreateableTopicConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateableTopicConfig))
 @settings(max_examples=1)
 def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> None:
@@ -48,6 +51,7 @@ def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> N
 read_creatable_topic: Final = entity_reader(CreatableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopic))
 @settings(max_examples=1)
 def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
@@ -62,6 +66,7 @@ def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
 read_create_topics_request: Final = entity_reader(CreateTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsRequest))
 @settings(max_examples=1)
 def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
@@ -73,6 +78,7 @@ def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateTopicsRequest))
 def test_create_topics_request_java(
     instance: CreateTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v4_response.py
+++ b/tests/generated/test_create_topics_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_creatable_topic_result: Final = entity_reader(CreatableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicResult))
 @settings(max_examples=1)
 def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> None:
@@ -29,6 +31,7 @@ def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> Non
 read_create_topics_response: Final = entity_reader(CreateTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsResponse))
 @settings(max_examples=1)
 def test_create_topics_response_roundtrip(instance: CreateTopicsResponse) -> None:

--- a/tests/generated/test_create_topics_v5_request.py
+++ b/tests/generated/test_create_topics_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_creatable_replica_assignment: Final = entity_reader(CreatableReplicaAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableReplicaAssignment))
 @settings(max_examples=1)
 def test_creatable_replica_assignment_roundtrip(
@@ -34,6 +36,7 @@ def test_creatable_replica_assignment_roundtrip(
 read_createable_topic_config: Final = entity_reader(CreateableTopicConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateableTopicConfig))
 @settings(max_examples=1)
 def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> None:
@@ -48,6 +51,7 @@ def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> N
 read_creatable_topic: Final = entity_reader(CreatableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopic))
 @settings(max_examples=1)
 def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
@@ -62,6 +66,7 @@ def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
 read_create_topics_request: Final = entity_reader(CreateTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsRequest))
 @settings(max_examples=1)
 def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
@@ -73,6 +78,7 @@ def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateTopicsRequest))
 def test_create_topics_request_java(
     instance: CreateTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v5_response.py
+++ b/tests/generated/test_create_topics_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_creatable_topic_configs: Final = entity_reader(CreatableTopicConfigs)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicConfigs))
 @settings(max_examples=1)
 def test_creatable_topic_configs_roundtrip(instance: CreatableTopicConfigs) -> None:
@@ -30,6 +32,7 @@ def test_creatable_topic_configs_roundtrip(instance: CreatableTopicConfigs) -> N
 read_creatable_topic_result: Final = entity_reader(CreatableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicResult))
 @settings(max_examples=1)
 def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> None:
@@ -44,6 +47,7 @@ def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> Non
 read_create_topics_response: Final = entity_reader(CreateTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsResponse))
 @settings(max_examples=1)
 def test_create_topics_response_roundtrip(instance: CreateTopicsResponse) -> None:

--- a/tests/generated/test_create_topics_v6_request.py
+++ b/tests/generated/test_create_topics_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_creatable_replica_assignment: Final = entity_reader(CreatableReplicaAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableReplicaAssignment))
 @settings(max_examples=1)
 def test_creatable_replica_assignment_roundtrip(
@@ -34,6 +36,7 @@ def test_creatable_replica_assignment_roundtrip(
 read_createable_topic_config: Final = entity_reader(CreateableTopicConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateableTopicConfig))
 @settings(max_examples=1)
 def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> None:
@@ -48,6 +51,7 @@ def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> N
 read_creatable_topic: Final = entity_reader(CreatableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopic))
 @settings(max_examples=1)
 def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
@@ -62,6 +66,7 @@ def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
 read_create_topics_request: Final = entity_reader(CreateTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsRequest))
 @settings(max_examples=1)
 def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
@@ -73,6 +78,7 @@ def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateTopicsRequest))
 def test_create_topics_request_java(
     instance: CreateTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v6_response.py
+++ b/tests/generated/test_create_topics_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_creatable_topic_configs: Final = entity_reader(CreatableTopicConfigs)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicConfigs))
 @settings(max_examples=1)
 def test_creatable_topic_configs_roundtrip(instance: CreatableTopicConfigs) -> None:
@@ -30,6 +32,7 @@ def test_creatable_topic_configs_roundtrip(instance: CreatableTopicConfigs) -> N
 read_creatable_topic_result: Final = entity_reader(CreatableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicResult))
 @settings(max_examples=1)
 def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> None:
@@ -44,6 +47,7 @@ def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> Non
 read_create_topics_response: Final = entity_reader(CreateTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsResponse))
 @settings(max_examples=1)
 def test_create_topics_response_roundtrip(instance: CreateTopicsResponse) -> None:

--- a/tests/generated/test_create_topics_v7_request.py
+++ b/tests/generated/test_create_topics_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_creatable_replica_assignment: Final = entity_reader(CreatableReplicaAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableReplicaAssignment))
 @settings(max_examples=1)
 def test_creatable_replica_assignment_roundtrip(
@@ -34,6 +36,7 @@ def test_creatable_replica_assignment_roundtrip(
 read_createable_topic_config: Final = entity_reader(CreateableTopicConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateableTopicConfig))
 @settings(max_examples=1)
 def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> None:
@@ -48,6 +51,7 @@ def test_createable_topic_config_roundtrip(instance: CreateableTopicConfig) -> N
 read_creatable_topic: Final = entity_reader(CreatableTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopic))
 @settings(max_examples=1)
 def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
@@ -62,6 +66,7 @@ def test_creatable_topic_roundtrip(instance: CreatableTopic) -> None:
 read_create_topics_request: Final = entity_reader(CreateTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsRequest))
 @settings(max_examples=1)
 def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
@@ -73,6 +78,7 @@ def test_create_topics_request_roundtrip(instance: CreateTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(CreateTopicsRequest))
 def test_create_topics_request_java(
     instance: CreateTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_create_topics_v7_response.py
+++ b/tests/generated/test_create_topics_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_creatable_topic_configs: Final = entity_reader(CreatableTopicConfigs)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicConfigs))
 @settings(max_examples=1)
 def test_creatable_topic_configs_roundtrip(instance: CreatableTopicConfigs) -> None:
@@ -30,6 +32,7 @@ def test_creatable_topic_configs_roundtrip(instance: CreatableTopicConfigs) -> N
 read_creatable_topic_result: Final = entity_reader(CreatableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreatableTopicResult))
 @settings(max_examples=1)
 def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> None:
@@ -44,6 +47,7 @@ def test_creatable_topic_result_roundtrip(instance: CreatableTopicResult) -> Non
 read_create_topics_response: Final = entity_reader(CreateTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CreateTopicsResponse))
 @settings(max_examples=1)
 def test_create_topics_response_roundtrip(instance: CreateTopicsResponse) -> None:

--- a/tests/generated/test_default_principal_data_v0_data.py
+++ b/tests/generated/test_default_principal_data_v0_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_default_principal_data: Final = entity_reader(DefaultPrincipalData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DefaultPrincipalData))
 @settings(max_examples=1)
 def test_default_principal_data_roundtrip(instance: DefaultPrincipalData) -> None:
@@ -26,6 +28,7 @@ def test_default_principal_data_roundtrip(instance: DefaultPrincipalData) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DefaultPrincipalData))
 def test_default_principal_data_java(
     instance: DefaultPrincipalData, java_tester: JavaTester

--- a/tests/generated/test_delete_acls_v0_request.py
+++ b/tests/generated/test_delete_acls_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_delete_acls_filter: Final = entity_reader(DeleteAclsFilter)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsFilter))
 @settings(max_examples=1)
 def test_delete_acls_filter_roundtrip(instance: DeleteAclsFilter) -> None:
@@ -30,6 +32,7 @@ def test_delete_acls_filter_roundtrip(instance: DeleteAclsFilter) -> None:
 read_delete_acls_request: Final = entity_reader(DeleteAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsRequest))
 @settings(max_examples=1)
 def test_delete_acls_request_roundtrip(instance: DeleteAclsRequest) -> None:
@@ -41,6 +44,7 @@ def test_delete_acls_request_roundtrip(instance: DeleteAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteAclsRequest))
 def test_delete_acls_request_java(
     instance: DeleteAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_acls_v0_response.py
+++ b/tests/generated/test_delete_acls_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_delete_acls_matching_acl: Final = entity_reader(DeleteAclsMatchingAcl)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsMatchingAcl))
 @settings(max_examples=1)
 def test_delete_acls_matching_acl_roundtrip(instance: DeleteAclsMatchingAcl) -> None:
@@ -31,6 +33,7 @@ def test_delete_acls_matching_acl_roundtrip(instance: DeleteAclsMatchingAcl) -> 
 read_delete_acls_filter_result: Final = entity_reader(DeleteAclsFilterResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsFilterResult))
 @settings(max_examples=1)
 def test_delete_acls_filter_result_roundtrip(instance: DeleteAclsFilterResult) -> None:
@@ -45,6 +48,7 @@ def test_delete_acls_filter_result_roundtrip(instance: DeleteAclsFilterResult) -
 read_delete_acls_response: Final = entity_reader(DeleteAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsResponse))
 @settings(max_examples=1)
 def test_delete_acls_response_roundtrip(instance: DeleteAclsResponse) -> None:
@@ -56,6 +60,7 @@ def test_delete_acls_response_roundtrip(instance: DeleteAclsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteAclsResponse))
 def test_delete_acls_response_java(
     instance: DeleteAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_acls_v1_request.py
+++ b/tests/generated/test_delete_acls_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_delete_acls_filter: Final = entity_reader(DeleteAclsFilter)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsFilter))
 @settings(max_examples=1)
 def test_delete_acls_filter_roundtrip(instance: DeleteAclsFilter) -> None:
@@ -30,6 +32,7 @@ def test_delete_acls_filter_roundtrip(instance: DeleteAclsFilter) -> None:
 read_delete_acls_request: Final = entity_reader(DeleteAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsRequest))
 @settings(max_examples=1)
 def test_delete_acls_request_roundtrip(instance: DeleteAclsRequest) -> None:
@@ -41,6 +44,7 @@ def test_delete_acls_request_roundtrip(instance: DeleteAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteAclsRequest))
 def test_delete_acls_request_java(
     instance: DeleteAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_acls_v1_response.py
+++ b/tests/generated/test_delete_acls_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_delete_acls_matching_acl: Final = entity_reader(DeleteAclsMatchingAcl)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsMatchingAcl))
 @settings(max_examples=1)
 def test_delete_acls_matching_acl_roundtrip(instance: DeleteAclsMatchingAcl) -> None:
@@ -31,6 +33,7 @@ def test_delete_acls_matching_acl_roundtrip(instance: DeleteAclsMatchingAcl) -> 
 read_delete_acls_filter_result: Final = entity_reader(DeleteAclsFilterResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsFilterResult))
 @settings(max_examples=1)
 def test_delete_acls_filter_result_roundtrip(instance: DeleteAclsFilterResult) -> None:
@@ -45,6 +48,7 @@ def test_delete_acls_filter_result_roundtrip(instance: DeleteAclsFilterResult) -
 read_delete_acls_response: Final = entity_reader(DeleteAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsResponse))
 @settings(max_examples=1)
 def test_delete_acls_response_roundtrip(instance: DeleteAclsResponse) -> None:
@@ -56,6 +60,7 @@ def test_delete_acls_response_roundtrip(instance: DeleteAclsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteAclsResponse))
 def test_delete_acls_response_java(
     instance: DeleteAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_acls_v2_request.py
+++ b/tests/generated/test_delete_acls_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_delete_acls_filter: Final = entity_reader(DeleteAclsFilter)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsFilter))
 @settings(max_examples=1)
 def test_delete_acls_filter_roundtrip(instance: DeleteAclsFilter) -> None:
@@ -30,6 +32,7 @@ def test_delete_acls_filter_roundtrip(instance: DeleteAclsFilter) -> None:
 read_delete_acls_request: Final = entity_reader(DeleteAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsRequest))
 @settings(max_examples=1)
 def test_delete_acls_request_roundtrip(instance: DeleteAclsRequest) -> None:
@@ -41,6 +44,7 @@ def test_delete_acls_request_roundtrip(instance: DeleteAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteAclsRequest))
 def test_delete_acls_request_java(
     instance: DeleteAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_acls_v2_response.py
+++ b/tests/generated/test_delete_acls_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_delete_acls_matching_acl: Final = entity_reader(DeleteAclsMatchingAcl)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsMatchingAcl))
 @settings(max_examples=1)
 def test_delete_acls_matching_acl_roundtrip(instance: DeleteAclsMatchingAcl) -> None:
@@ -31,6 +33,7 @@ def test_delete_acls_matching_acl_roundtrip(instance: DeleteAclsMatchingAcl) -> 
 read_delete_acls_filter_result: Final = entity_reader(DeleteAclsFilterResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsFilterResult))
 @settings(max_examples=1)
 def test_delete_acls_filter_result_roundtrip(instance: DeleteAclsFilterResult) -> None:
@@ -45,6 +48,7 @@ def test_delete_acls_filter_result_roundtrip(instance: DeleteAclsFilterResult) -
 read_delete_acls_response: Final = entity_reader(DeleteAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsResponse))
 @settings(max_examples=1)
 def test_delete_acls_response_roundtrip(instance: DeleteAclsResponse) -> None:
@@ -56,6 +60,7 @@ def test_delete_acls_response_roundtrip(instance: DeleteAclsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteAclsResponse))
 def test_delete_acls_response_java(
     instance: DeleteAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_acls_v3_request.py
+++ b/tests/generated/test_delete_acls_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_delete_acls_filter: Final = entity_reader(DeleteAclsFilter)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsFilter))
 @settings(max_examples=1)
 def test_delete_acls_filter_roundtrip(instance: DeleteAclsFilter) -> None:
@@ -30,6 +32,7 @@ def test_delete_acls_filter_roundtrip(instance: DeleteAclsFilter) -> None:
 read_delete_acls_request: Final = entity_reader(DeleteAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsRequest))
 @settings(max_examples=1)
 def test_delete_acls_request_roundtrip(instance: DeleteAclsRequest) -> None:
@@ -41,6 +44,7 @@ def test_delete_acls_request_roundtrip(instance: DeleteAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteAclsRequest))
 def test_delete_acls_request_java(
     instance: DeleteAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_acls_v3_response.py
+++ b/tests/generated/test_delete_acls_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_delete_acls_matching_acl: Final = entity_reader(DeleteAclsMatchingAcl)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsMatchingAcl))
 @settings(max_examples=1)
 def test_delete_acls_matching_acl_roundtrip(instance: DeleteAclsMatchingAcl) -> None:
@@ -31,6 +33,7 @@ def test_delete_acls_matching_acl_roundtrip(instance: DeleteAclsMatchingAcl) -> 
 read_delete_acls_filter_result: Final = entity_reader(DeleteAclsFilterResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsFilterResult))
 @settings(max_examples=1)
 def test_delete_acls_filter_result_roundtrip(instance: DeleteAclsFilterResult) -> None:
@@ -45,6 +48,7 @@ def test_delete_acls_filter_result_roundtrip(instance: DeleteAclsFilterResult) -
 read_delete_acls_response: Final = entity_reader(DeleteAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteAclsResponse))
 @settings(max_examples=1)
 def test_delete_acls_response_roundtrip(instance: DeleteAclsResponse) -> None:
@@ -56,6 +60,7 @@ def test_delete_acls_response_roundtrip(instance: DeleteAclsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteAclsResponse))
 def test_delete_acls_response_java(
     instance: DeleteAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_groups_v0_request.py
+++ b/tests/generated/test_delete_groups_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_groups_request: Final = entity_reader(DeleteGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteGroupsRequest))
 @settings(max_examples=1)
 def test_delete_groups_request_roundtrip(instance: DeleteGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_groups_request_roundtrip(instance: DeleteGroupsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteGroupsRequest))
 def test_delete_groups_request_java(
     instance: DeleteGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_groups_v0_response.py
+++ b/tests/generated/test_delete_groups_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_group_result: Final = entity_reader(DeletableGroupResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableGroupResult))
 @settings(max_examples=1)
 def test_deletable_group_result_roundtrip(instance: DeletableGroupResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_group_result_roundtrip(instance: DeletableGroupResult) -> Non
 read_delete_groups_response: Final = entity_reader(DeleteGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteGroupsResponse))
 @settings(max_examples=1)
 def test_delete_groups_response_roundtrip(instance: DeleteGroupsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_groups_response_roundtrip(instance: DeleteGroupsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteGroupsResponse))
 def test_delete_groups_response_java(
     instance: DeleteGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_groups_v1_request.py
+++ b/tests/generated/test_delete_groups_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_groups_request: Final = entity_reader(DeleteGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteGroupsRequest))
 @settings(max_examples=1)
 def test_delete_groups_request_roundtrip(instance: DeleteGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_groups_request_roundtrip(instance: DeleteGroupsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteGroupsRequest))
 def test_delete_groups_request_java(
     instance: DeleteGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_groups_v1_response.py
+++ b/tests/generated/test_delete_groups_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_group_result: Final = entity_reader(DeletableGroupResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableGroupResult))
 @settings(max_examples=1)
 def test_deletable_group_result_roundtrip(instance: DeletableGroupResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_group_result_roundtrip(instance: DeletableGroupResult) -> Non
 read_delete_groups_response: Final = entity_reader(DeleteGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteGroupsResponse))
 @settings(max_examples=1)
 def test_delete_groups_response_roundtrip(instance: DeleteGroupsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_groups_response_roundtrip(instance: DeleteGroupsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteGroupsResponse))
 def test_delete_groups_response_java(
     instance: DeleteGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_groups_v2_request.py
+++ b/tests/generated/test_delete_groups_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_groups_request: Final = entity_reader(DeleteGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteGroupsRequest))
 @settings(max_examples=1)
 def test_delete_groups_request_roundtrip(instance: DeleteGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_groups_request_roundtrip(instance: DeleteGroupsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteGroupsRequest))
 def test_delete_groups_request_java(
     instance: DeleteGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_groups_v2_response.py
+++ b/tests/generated/test_delete_groups_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_group_result: Final = entity_reader(DeletableGroupResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableGroupResult))
 @settings(max_examples=1)
 def test_deletable_group_result_roundtrip(instance: DeletableGroupResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_group_result_roundtrip(instance: DeletableGroupResult) -> Non
 read_delete_groups_response: Final = entity_reader(DeleteGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteGroupsResponse))
 @settings(max_examples=1)
 def test_delete_groups_response_roundtrip(instance: DeleteGroupsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_groups_response_roundtrip(instance: DeleteGroupsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteGroupsResponse))
 def test_delete_groups_response_java(
     instance: DeleteGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_records_v0_request.py
+++ b/tests/generated/test_delete_records_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_delete_records_partition: Final = entity_reader(DeleteRecordsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsPartition))
 @settings(max_examples=1)
 def test_delete_records_partition_roundtrip(instance: DeleteRecordsPartition) -> None:
@@ -31,6 +33,7 @@ def test_delete_records_partition_roundtrip(instance: DeleteRecordsPartition) ->
 read_delete_records_topic: Final = entity_reader(DeleteRecordsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsTopic))
 @settings(max_examples=1)
 def test_delete_records_topic_roundtrip(instance: DeleteRecordsTopic) -> None:
@@ -45,6 +48,7 @@ def test_delete_records_topic_roundtrip(instance: DeleteRecordsTopic) -> None:
 read_delete_records_request: Final = entity_reader(DeleteRecordsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsRequest))
 @settings(max_examples=1)
 def test_delete_records_request_roundtrip(instance: DeleteRecordsRequest) -> None:
@@ -56,6 +60,7 @@ def test_delete_records_request_roundtrip(instance: DeleteRecordsRequest) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteRecordsRequest))
 def test_delete_records_request_java(
     instance: DeleteRecordsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_records_v0_response.py
+++ b/tests/generated/test_delete_records_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_delete_records_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsPartitionResult))
 @settings(max_examples=1)
 def test_delete_records_partition_result_roundtrip(
@@ -35,6 +37,7 @@ def test_delete_records_partition_result_roundtrip(
 read_delete_records_topic_result: Final = entity_reader(DeleteRecordsTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsTopicResult))
 @settings(max_examples=1)
 def test_delete_records_topic_result_roundtrip(
@@ -51,6 +54,7 @@ def test_delete_records_topic_result_roundtrip(
 read_delete_records_response: Final = entity_reader(DeleteRecordsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsResponse))
 @settings(max_examples=1)
 def test_delete_records_response_roundtrip(instance: DeleteRecordsResponse) -> None:
@@ -62,6 +66,7 @@ def test_delete_records_response_roundtrip(instance: DeleteRecordsResponse) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteRecordsResponse))
 def test_delete_records_response_java(
     instance: DeleteRecordsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_records_v1_request.py
+++ b/tests/generated/test_delete_records_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_delete_records_partition: Final = entity_reader(DeleteRecordsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsPartition))
 @settings(max_examples=1)
 def test_delete_records_partition_roundtrip(instance: DeleteRecordsPartition) -> None:
@@ -31,6 +33,7 @@ def test_delete_records_partition_roundtrip(instance: DeleteRecordsPartition) ->
 read_delete_records_topic: Final = entity_reader(DeleteRecordsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsTopic))
 @settings(max_examples=1)
 def test_delete_records_topic_roundtrip(instance: DeleteRecordsTopic) -> None:
@@ -45,6 +48,7 @@ def test_delete_records_topic_roundtrip(instance: DeleteRecordsTopic) -> None:
 read_delete_records_request: Final = entity_reader(DeleteRecordsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsRequest))
 @settings(max_examples=1)
 def test_delete_records_request_roundtrip(instance: DeleteRecordsRequest) -> None:
@@ -56,6 +60,7 @@ def test_delete_records_request_roundtrip(instance: DeleteRecordsRequest) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteRecordsRequest))
 def test_delete_records_request_java(
     instance: DeleteRecordsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_records_v1_response.py
+++ b/tests/generated/test_delete_records_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_delete_records_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsPartitionResult))
 @settings(max_examples=1)
 def test_delete_records_partition_result_roundtrip(
@@ -35,6 +37,7 @@ def test_delete_records_partition_result_roundtrip(
 read_delete_records_topic_result: Final = entity_reader(DeleteRecordsTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsTopicResult))
 @settings(max_examples=1)
 def test_delete_records_topic_result_roundtrip(
@@ -51,6 +54,7 @@ def test_delete_records_topic_result_roundtrip(
 read_delete_records_response: Final = entity_reader(DeleteRecordsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsResponse))
 @settings(max_examples=1)
 def test_delete_records_response_roundtrip(instance: DeleteRecordsResponse) -> None:
@@ -62,6 +66,7 @@ def test_delete_records_response_roundtrip(instance: DeleteRecordsResponse) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteRecordsResponse))
 def test_delete_records_response_java(
     instance: DeleteRecordsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_records_v2_request.py
+++ b/tests/generated/test_delete_records_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_delete_records_partition: Final = entity_reader(DeleteRecordsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsPartition))
 @settings(max_examples=1)
 def test_delete_records_partition_roundtrip(instance: DeleteRecordsPartition) -> None:
@@ -31,6 +33,7 @@ def test_delete_records_partition_roundtrip(instance: DeleteRecordsPartition) ->
 read_delete_records_topic: Final = entity_reader(DeleteRecordsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsTopic))
 @settings(max_examples=1)
 def test_delete_records_topic_roundtrip(instance: DeleteRecordsTopic) -> None:
@@ -45,6 +48,7 @@ def test_delete_records_topic_roundtrip(instance: DeleteRecordsTopic) -> None:
 read_delete_records_request: Final = entity_reader(DeleteRecordsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsRequest))
 @settings(max_examples=1)
 def test_delete_records_request_roundtrip(instance: DeleteRecordsRequest) -> None:
@@ -56,6 +60,7 @@ def test_delete_records_request_roundtrip(instance: DeleteRecordsRequest) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteRecordsRequest))
 def test_delete_records_request_java(
     instance: DeleteRecordsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_records_v2_response.py
+++ b/tests/generated/test_delete_records_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_delete_records_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsPartitionResult))
 @settings(max_examples=1)
 def test_delete_records_partition_result_roundtrip(
@@ -35,6 +37,7 @@ def test_delete_records_partition_result_roundtrip(
 read_delete_records_topic_result: Final = entity_reader(DeleteRecordsTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsTopicResult))
 @settings(max_examples=1)
 def test_delete_records_topic_result_roundtrip(
@@ -51,6 +54,7 @@ def test_delete_records_topic_result_roundtrip(
 read_delete_records_response: Final = entity_reader(DeleteRecordsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteRecordsResponse))
 @settings(max_examples=1)
 def test_delete_records_response_roundtrip(instance: DeleteRecordsResponse) -> None:
@@ -62,6 +66,7 @@ def test_delete_records_response_roundtrip(instance: DeleteRecordsResponse) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteRecordsResponse))
 def test_delete_records_response_java(
     instance: DeleteRecordsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v0_request.py
+++ b/tests/generated/test_delete_topics_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_topics_request: Final = entity_reader(DeleteTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsRequest))
 @settings(max_examples=1)
 def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsRequest))
 def test_delete_topics_request_java(
     instance: DeleteTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v0_response.py
+++ b/tests/generated/test_delete_topics_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_topic_result: Final = entity_reader(DeletableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableTopicResult))
 @settings(max_examples=1)
 def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> Non
 read_delete_topics_response: Final = entity_reader(DeleteTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsResponse))
 @settings(max_examples=1)
 def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsResponse))
 def test_delete_topics_response_java(
     instance: DeleteTopicsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v1_request.py
+++ b/tests/generated/test_delete_topics_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_topics_request: Final = entity_reader(DeleteTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsRequest))
 @settings(max_examples=1)
 def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsRequest))
 def test_delete_topics_request_java(
     instance: DeleteTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v1_response.py
+++ b/tests/generated/test_delete_topics_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_topic_result: Final = entity_reader(DeletableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableTopicResult))
 @settings(max_examples=1)
 def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> Non
 read_delete_topics_response: Final = entity_reader(DeleteTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsResponse))
 @settings(max_examples=1)
 def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsResponse))
 def test_delete_topics_response_java(
     instance: DeleteTopicsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v2_request.py
+++ b/tests/generated/test_delete_topics_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_topics_request: Final = entity_reader(DeleteTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsRequest))
 @settings(max_examples=1)
 def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsRequest))
 def test_delete_topics_request_java(
     instance: DeleteTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v2_response.py
+++ b/tests/generated/test_delete_topics_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_topic_result: Final = entity_reader(DeletableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableTopicResult))
 @settings(max_examples=1)
 def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> Non
 read_delete_topics_response: Final = entity_reader(DeleteTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsResponse))
 @settings(max_examples=1)
 def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsResponse))
 def test_delete_topics_response_java(
     instance: DeleteTopicsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v3_request.py
+++ b/tests/generated/test_delete_topics_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_topics_request: Final = entity_reader(DeleteTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsRequest))
 @settings(max_examples=1)
 def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsRequest))
 def test_delete_topics_request_java(
     instance: DeleteTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v3_response.py
+++ b/tests/generated/test_delete_topics_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_topic_result: Final = entity_reader(DeletableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableTopicResult))
 @settings(max_examples=1)
 def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> Non
 read_delete_topics_response: Final = entity_reader(DeleteTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsResponse))
 @settings(max_examples=1)
 def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsResponse))
 def test_delete_topics_response_java(
     instance: DeleteTopicsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v4_request.py
+++ b/tests/generated/test_delete_topics_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_topics_request: Final = entity_reader(DeleteTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsRequest))
 @settings(max_examples=1)
 def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsRequest))
 def test_delete_topics_request_java(
     instance: DeleteTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v4_response.py
+++ b/tests/generated/test_delete_topics_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_topic_result: Final = entity_reader(DeletableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableTopicResult))
 @settings(max_examples=1)
 def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> Non
 read_delete_topics_response: Final = entity_reader(DeleteTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsResponse))
 @settings(max_examples=1)
 def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsResponse))
 def test_delete_topics_response_java(
     instance: DeleteTopicsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v5_request.py
+++ b/tests/generated/test_delete_topics_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_delete_topics_request: Final = entity_reader(DeleteTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsRequest))
 @settings(max_examples=1)
 def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
@@ -26,6 +28,7 @@ def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsRequest))
 def test_delete_topics_request_java(
     instance: DeleteTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v5_response.py
+++ b/tests/generated/test_delete_topics_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_topic_result: Final = entity_reader(DeletableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableTopicResult))
 @settings(max_examples=1)
 def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> Non
 read_delete_topics_response: Final = entity_reader(DeleteTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsResponse))
 @settings(max_examples=1)
 def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsResponse))
 def test_delete_topics_response_java(
     instance: DeleteTopicsResponse, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v6_request.py
+++ b/tests/generated/test_delete_topics_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_delete_topic_state: Final = entity_reader(DeleteTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicState))
 @settings(max_examples=1)
 def test_delete_topic_state_roundtrip(instance: DeleteTopicState) -> None:
@@ -30,6 +32,7 @@ def test_delete_topic_state_roundtrip(instance: DeleteTopicState) -> None:
 read_delete_topics_request: Final = entity_reader(DeleteTopicsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsRequest))
 @settings(max_examples=1)
 def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
@@ -41,6 +44,7 @@ def test_delete_topics_request_roundtrip(instance: DeleteTopicsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsRequest))
 def test_delete_topics_request_java(
     instance: DeleteTopicsRequest, java_tester: JavaTester

--- a/tests/generated/test_delete_topics_v6_response.py
+++ b/tests/generated/test_delete_topics_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_deletable_topic_result: Final = entity_reader(DeletableTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeletableTopicResult))
 @settings(max_examples=1)
 def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> None:
@@ -30,6 +32,7 @@ def test_deletable_topic_result_roundtrip(instance: DeletableTopicResult) -> Non
 read_delete_topics_response: Final = entity_reader(DeleteTopicsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DeleteTopicsResponse))
 @settings(max_examples=1)
 def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> None:
@@ -41,6 +44,7 @@ def test_delete_topics_response_roundtrip(instance: DeleteTopicsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DeleteTopicsResponse))
 def test_delete_topics_response_java(
     instance: DeleteTopicsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_acls_v0_request.py
+++ b/tests/generated/test_describe_acls_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_acls_request: Final = entity_reader(DescribeAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsRequest))
 @settings(max_examples=1)
 def test_describe_acls_request_roundtrip(instance: DescribeAclsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_acls_request_roundtrip(instance: DescribeAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeAclsRequest))
 def test_describe_acls_request_java(
     instance: DescribeAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_acls_v0_response.py
+++ b/tests/generated/test_describe_acls_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_acl_description: Final = entity_reader(AclDescription)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclDescription))
 @settings(max_examples=1)
 def test_acl_description_roundtrip(instance: AclDescription) -> None:
@@ -31,6 +33,7 @@ def test_acl_description_roundtrip(instance: AclDescription) -> None:
 read_describe_acls_resource: Final = entity_reader(DescribeAclsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsResource))
 @settings(max_examples=1)
 def test_describe_acls_resource_roundtrip(instance: DescribeAclsResource) -> None:
@@ -45,6 +48,7 @@ def test_describe_acls_resource_roundtrip(instance: DescribeAclsResource) -> Non
 read_describe_acls_response: Final = entity_reader(DescribeAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsResponse))
 @settings(max_examples=1)
 def test_describe_acls_response_roundtrip(instance: DescribeAclsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_acls_response_roundtrip(instance: DescribeAclsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeAclsResponse))
 def test_describe_acls_response_java(
     instance: DescribeAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_acls_v1_request.py
+++ b/tests/generated/test_describe_acls_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_acls_request: Final = entity_reader(DescribeAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsRequest))
 @settings(max_examples=1)
 def test_describe_acls_request_roundtrip(instance: DescribeAclsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_acls_request_roundtrip(instance: DescribeAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeAclsRequest))
 def test_describe_acls_request_java(
     instance: DescribeAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_acls_v1_response.py
+++ b/tests/generated/test_describe_acls_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_acl_description: Final = entity_reader(AclDescription)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclDescription))
 @settings(max_examples=1)
 def test_acl_description_roundtrip(instance: AclDescription) -> None:
@@ -31,6 +33,7 @@ def test_acl_description_roundtrip(instance: AclDescription) -> None:
 read_describe_acls_resource: Final = entity_reader(DescribeAclsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsResource))
 @settings(max_examples=1)
 def test_describe_acls_resource_roundtrip(instance: DescribeAclsResource) -> None:
@@ -45,6 +48,7 @@ def test_describe_acls_resource_roundtrip(instance: DescribeAclsResource) -> Non
 read_describe_acls_response: Final = entity_reader(DescribeAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsResponse))
 @settings(max_examples=1)
 def test_describe_acls_response_roundtrip(instance: DescribeAclsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_acls_response_roundtrip(instance: DescribeAclsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeAclsResponse))
 def test_describe_acls_response_java(
     instance: DescribeAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_acls_v2_request.py
+++ b/tests/generated/test_describe_acls_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_acls_request: Final = entity_reader(DescribeAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsRequest))
 @settings(max_examples=1)
 def test_describe_acls_request_roundtrip(instance: DescribeAclsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_acls_request_roundtrip(instance: DescribeAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeAclsRequest))
 def test_describe_acls_request_java(
     instance: DescribeAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_acls_v2_response.py
+++ b/tests/generated/test_describe_acls_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_acl_description: Final = entity_reader(AclDescription)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclDescription))
 @settings(max_examples=1)
 def test_acl_description_roundtrip(instance: AclDescription) -> None:
@@ -31,6 +33,7 @@ def test_acl_description_roundtrip(instance: AclDescription) -> None:
 read_describe_acls_resource: Final = entity_reader(DescribeAclsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsResource))
 @settings(max_examples=1)
 def test_describe_acls_resource_roundtrip(instance: DescribeAclsResource) -> None:
@@ -45,6 +48,7 @@ def test_describe_acls_resource_roundtrip(instance: DescribeAclsResource) -> Non
 read_describe_acls_response: Final = entity_reader(DescribeAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsResponse))
 @settings(max_examples=1)
 def test_describe_acls_response_roundtrip(instance: DescribeAclsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_acls_response_roundtrip(instance: DescribeAclsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeAclsResponse))
 def test_describe_acls_response_java(
     instance: DescribeAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_acls_v3_request.py
+++ b/tests/generated/test_describe_acls_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_acls_request: Final = entity_reader(DescribeAclsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsRequest))
 @settings(max_examples=1)
 def test_describe_acls_request_roundtrip(instance: DescribeAclsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_acls_request_roundtrip(instance: DescribeAclsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeAclsRequest))
 def test_describe_acls_request_java(
     instance: DescribeAclsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_acls_v3_response.py
+++ b/tests/generated/test_describe_acls_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_acl_description: Final = entity_reader(AclDescription)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AclDescription))
 @settings(max_examples=1)
 def test_acl_description_roundtrip(instance: AclDescription) -> None:
@@ -31,6 +33,7 @@ def test_acl_description_roundtrip(instance: AclDescription) -> None:
 read_describe_acls_resource: Final = entity_reader(DescribeAclsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsResource))
 @settings(max_examples=1)
 def test_describe_acls_resource_roundtrip(instance: DescribeAclsResource) -> None:
@@ -45,6 +48,7 @@ def test_describe_acls_resource_roundtrip(instance: DescribeAclsResource) -> Non
 read_describe_acls_response: Final = entity_reader(DescribeAclsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeAclsResponse))
 @settings(max_examples=1)
 def test_describe_acls_response_roundtrip(instance: DescribeAclsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_acls_response_roundtrip(instance: DescribeAclsResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeAclsResponse))
 def test_describe_acls_response_java(
     instance: DescribeAclsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_client_quotas_v0_request.py
+++ b/tests/generated/test_describe_client_quotas_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_component_data: Final = entity_reader(ComponentData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ComponentData))
 @settings(max_examples=1)
 def test_component_data_roundtrip(instance: ComponentData) -> None:
@@ -30,6 +32,7 @@ def test_component_data_roundtrip(instance: ComponentData) -> None:
 read_describe_client_quotas_request: Final = entity_reader(DescribeClientQuotasRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeClientQuotasRequest))
 @settings(max_examples=1)
 def test_describe_client_quotas_request_roundtrip(
@@ -43,6 +46,7 @@ def test_describe_client_quotas_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeClientQuotasRequest))
 def test_describe_client_quotas_request_java(
     instance: DescribeClientQuotasRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_client_quotas_v0_response.py
+++ b/tests/generated/test_describe_client_quotas_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_entity_data: Final = entity_reader(EntityData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntityData))
 @settings(max_examples=1)
 def test_entity_data_roundtrip(instance: EntityData) -> None:
@@ -32,6 +34,7 @@ def test_entity_data_roundtrip(instance: EntityData) -> None:
 read_value_data: Final = entity_reader(ValueData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ValueData))
 @settings(max_examples=1)
 def test_value_data_roundtrip(instance: ValueData) -> None:
@@ -46,6 +49,7 @@ def test_value_data_roundtrip(instance: ValueData) -> None:
 read_entry_data: Final = entity_reader(EntryData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntryData))
 @settings(max_examples=1)
 def test_entry_data_roundtrip(instance: EntryData) -> None:
@@ -62,6 +66,7 @@ read_describe_client_quotas_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeClientQuotasResponse))
 @settings(max_examples=1)
 def test_describe_client_quotas_response_roundtrip(
@@ -75,6 +80,7 @@ def test_describe_client_quotas_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeClientQuotasResponse))
 def test_describe_client_quotas_response_java(
     instance: DescribeClientQuotasResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_client_quotas_v1_request.py
+++ b/tests/generated/test_describe_client_quotas_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_component_data: Final = entity_reader(ComponentData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ComponentData))
 @settings(max_examples=1)
 def test_component_data_roundtrip(instance: ComponentData) -> None:
@@ -30,6 +32,7 @@ def test_component_data_roundtrip(instance: ComponentData) -> None:
 read_describe_client_quotas_request: Final = entity_reader(DescribeClientQuotasRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeClientQuotasRequest))
 @settings(max_examples=1)
 def test_describe_client_quotas_request_roundtrip(
@@ -43,6 +46,7 @@ def test_describe_client_quotas_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeClientQuotasRequest))
 def test_describe_client_quotas_request_java(
     instance: DescribeClientQuotasRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_client_quotas_v1_response.py
+++ b/tests/generated/test_describe_client_quotas_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_entity_data: Final = entity_reader(EntityData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntityData))
 @settings(max_examples=1)
 def test_entity_data_roundtrip(instance: EntityData) -> None:
@@ -32,6 +34,7 @@ def test_entity_data_roundtrip(instance: EntityData) -> None:
 read_value_data: Final = entity_reader(ValueData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ValueData))
 @settings(max_examples=1)
 def test_value_data_roundtrip(instance: ValueData) -> None:
@@ -46,6 +49,7 @@ def test_value_data_roundtrip(instance: ValueData) -> None:
 read_entry_data: Final = entity_reader(EntryData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EntryData))
 @settings(max_examples=1)
 def test_entry_data_roundtrip(instance: EntryData) -> None:
@@ -62,6 +66,7 @@ read_describe_client_quotas_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeClientQuotasResponse))
 @settings(max_examples=1)
 def test_describe_client_quotas_response_roundtrip(
@@ -75,6 +80,7 @@ def test_describe_client_quotas_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeClientQuotasResponse))
 def test_describe_client_quotas_response_java(
     instance: DescribeClientQuotasResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_cluster_v0_request.py
+++ b/tests/generated/test_describe_cluster_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_cluster_request: Final = entity_reader(DescribeClusterRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeClusterRequest))
 @settings(max_examples=1)
 def test_describe_cluster_request_roundtrip(instance: DescribeClusterRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_cluster_request_roundtrip(instance: DescribeClusterRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeClusterRequest))
 def test_describe_cluster_request_java(
     instance: DescribeClusterRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_cluster_v0_response.py
+++ b/tests/generated/test_describe_cluster_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describe_cluster_broker: Final = entity_reader(DescribeClusterBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeClusterBroker))
 @settings(max_examples=1)
 def test_describe_cluster_broker_roundtrip(instance: DescribeClusterBroker) -> None:
@@ -30,6 +32,7 @@ def test_describe_cluster_broker_roundtrip(instance: DescribeClusterBroker) -> N
 read_describe_cluster_response: Final = entity_reader(DescribeClusterResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeClusterResponse))
 @settings(max_examples=1)
 def test_describe_cluster_response_roundtrip(instance: DescribeClusterResponse) -> None:
@@ -41,6 +44,7 @@ def test_describe_cluster_response_roundtrip(instance: DescribeClusterResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeClusterResponse))
 def test_describe_cluster_response_java(
     instance: DescribeClusterResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v0_request.py
+++ b/tests/generated/test_describe_configs_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_resource: Final = entity_reader(DescribeConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResource))
 @settings(max_examples=1)
 def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) -> None:
@@ -30,6 +32,7 @@ def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) 
 read_describe_configs_request: Final = entity_reader(DescribeConfigsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsRequest))
 @settings(max_examples=1)
 def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsRequest))
 def test_describe_configs_request_java(
     instance: DescribeConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v0_response.py
+++ b/tests/generated/test_describe_configs_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_describe_configs_resource_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResourceResult))
 @settings(max_examples=1)
 def test_describe_configs_resource_result_roundtrip(
@@ -35,6 +37,7 @@ def test_describe_configs_resource_result_roundtrip(
 read_describe_configs_result: Final = entity_reader(DescribeConfigsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResult))
 @settings(max_examples=1)
 def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> None:
@@ -49,6 +52,7 @@ def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> N
 read_describe_configs_response: Final = entity_reader(DescribeConfigsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResponse))
 @settings(max_examples=1)
 def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) -> None:
@@ -60,6 +64,7 @@ def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsResponse))
 def test_describe_configs_response_java(
     instance: DescribeConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v1_request.py
+++ b/tests/generated/test_describe_configs_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_resource: Final = entity_reader(DescribeConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResource))
 @settings(max_examples=1)
 def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) -> None:
@@ -30,6 +32,7 @@ def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) 
 read_describe_configs_request: Final = entity_reader(DescribeConfigsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsRequest))
 @settings(max_examples=1)
 def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsRequest))
 def test_describe_configs_request_java(
     instance: DescribeConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v1_response.py
+++ b/tests/generated/test_describe_configs_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_synonym: Final = entity_reader(DescribeConfigsSynonym)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsSynonym))
 @settings(max_examples=1)
 def test_describe_configs_synonym_roundtrip(instance: DescribeConfigsSynonym) -> None:
@@ -34,6 +36,7 @@ read_describe_configs_resource_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResourceResult))
 @settings(max_examples=1)
 def test_describe_configs_resource_result_roundtrip(
@@ -50,6 +53,7 @@ def test_describe_configs_resource_result_roundtrip(
 read_describe_configs_result: Final = entity_reader(DescribeConfigsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResult))
 @settings(max_examples=1)
 def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> None:
@@ -64,6 +68,7 @@ def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> N
 read_describe_configs_response: Final = entity_reader(DescribeConfigsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResponse))
 @settings(max_examples=1)
 def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) -> None:
@@ -75,6 +80,7 @@ def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsResponse))
 def test_describe_configs_response_java(
     instance: DescribeConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v2_request.py
+++ b/tests/generated/test_describe_configs_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_resource: Final = entity_reader(DescribeConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResource))
 @settings(max_examples=1)
 def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) -> None:
@@ -30,6 +32,7 @@ def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) 
 read_describe_configs_request: Final = entity_reader(DescribeConfigsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsRequest))
 @settings(max_examples=1)
 def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsRequest))
 def test_describe_configs_request_java(
     instance: DescribeConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v2_response.py
+++ b/tests/generated/test_describe_configs_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_synonym: Final = entity_reader(DescribeConfigsSynonym)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsSynonym))
 @settings(max_examples=1)
 def test_describe_configs_synonym_roundtrip(instance: DescribeConfigsSynonym) -> None:
@@ -34,6 +36,7 @@ read_describe_configs_resource_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResourceResult))
 @settings(max_examples=1)
 def test_describe_configs_resource_result_roundtrip(
@@ -50,6 +53,7 @@ def test_describe_configs_resource_result_roundtrip(
 read_describe_configs_result: Final = entity_reader(DescribeConfigsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResult))
 @settings(max_examples=1)
 def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> None:
@@ -64,6 +68,7 @@ def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> N
 read_describe_configs_response: Final = entity_reader(DescribeConfigsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResponse))
 @settings(max_examples=1)
 def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) -> None:
@@ -75,6 +80,7 @@ def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsResponse))
 def test_describe_configs_response_java(
     instance: DescribeConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v3_request.py
+++ b/tests/generated/test_describe_configs_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_resource: Final = entity_reader(DescribeConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResource))
 @settings(max_examples=1)
 def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) -> None:
@@ -30,6 +32,7 @@ def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) 
 read_describe_configs_request: Final = entity_reader(DescribeConfigsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsRequest))
 @settings(max_examples=1)
 def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsRequest))
 def test_describe_configs_request_java(
     instance: DescribeConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v3_response.py
+++ b/tests/generated/test_describe_configs_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_synonym: Final = entity_reader(DescribeConfigsSynonym)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsSynonym))
 @settings(max_examples=1)
 def test_describe_configs_synonym_roundtrip(instance: DescribeConfigsSynonym) -> None:
@@ -34,6 +36,7 @@ read_describe_configs_resource_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResourceResult))
 @settings(max_examples=1)
 def test_describe_configs_resource_result_roundtrip(
@@ -50,6 +53,7 @@ def test_describe_configs_resource_result_roundtrip(
 read_describe_configs_result: Final = entity_reader(DescribeConfigsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResult))
 @settings(max_examples=1)
 def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> None:
@@ -64,6 +68,7 @@ def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> N
 read_describe_configs_response: Final = entity_reader(DescribeConfigsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResponse))
 @settings(max_examples=1)
 def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) -> None:
@@ -75,6 +80,7 @@ def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsResponse))
 def test_describe_configs_response_java(
     instance: DescribeConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v4_request.py
+++ b/tests/generated/test_describe_configs_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_resource: Final = entity_reader(DescribeConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResource))
 @settings(max_examples=1)
 def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) -> None:
@@ -30,6 +32,7 @@ def test_describe_configs_resource_roundtrip(instance: DescribeConfigsResource) 
 read_describe_configs_request: Final = entity_reader(DescribeConfigsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsRequest))
 @settings(max_examples=1)
 def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_configs_request_roundtrip(instance: DescribeConfigsRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsRequest))
 def test_describe_configs_request_java(
     instance: DescribeConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_configs_v4_response.py
+++ b/tests/generated/test_describe_configs_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_configs_synonym: Final = entity_reader(DescribeConfigsSynonym)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsSynonym))
 @settings(max_examples=1)
 def test_describe_configs_synonym_roundtrip(instance: DescribeConfigsSynonym) -> None:
@@ -34,6 +36,7 @@ read_describe_configs_resource_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResourceResult))
 @settings(max_examples=1)
 def test_describe_configs_resource_result_roundtrip(
@@ -50,6 +53,7 @@ def test_describe_configs_resource_result_roundtrip(
 read_describe_configs_result: Final = entity_reader(DescribeConfigsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResult))
 @settings(max_examples=1)
 def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> None:
@@ -64,6 +68,7 @@ def test_describe_configs_result_roundtrip(instance: DescribeConfigsResult) -> N
 read_describe_configs_response: Final = entity_reader(DescribeConfigsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeConfigsResponse))
 @settings(max_examples=1)
 def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) -> None:
@@ -75,6 +80,7 @@ def test_describe_configs_response_roundtrip(instance: DescribeConfigsResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeConfigsResponse))
 def test_describe_configs_response_java(
     instance: DescribeConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_delegation_token_v0_request.py
+++ b/tests/generated/test_describe_delegation_token_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_describe_delegation_token_owner: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenOwner))
 @settings(max_examples=1)
 def test_describe_delegation_token_owner_roundtrip(
@@ -38,6 +40,7 @@ read_describe_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenRequest))
 @settings(max_examples=1)
 def test_describe_delegation_token_request_roundtrip(
@@ -51,6 +54,7 @@ def test_describe_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeDelegationTokenRequest))
 def test_describe_delegation_token_request_java(
     instance: DescribeDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_delegation_token_v0_response.py
+++ b/tests/generated/test_describe_delegation_token_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -23,6 +24,7 @@ read_described_delegation_token_renewer: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedDelegationTokenRenewer))
 @settings(max_examples=1)
 def test_described_delegation_token_renewer_roundtrip(
@@ -39,6 +41,7 @@ def test_described_delegation_token_renewer_roundtrip(
 read_described_delegation_token: Final = entity_reader(DescribedDelegationToken)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedDelegationToken))
 @settings(max_examples=1)
 def test_described_delegation_token_roundtrip(
@@ -57,6 +60,7 @@ read_describe_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenResponse))
 @settings(max_examples=1)
 def test_describe_delegation_token_response_roundtrip(
@@ -70,6 +74,7 @@ def test_describe_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeDelegationTokenResponse))
 def test_describe_delegation_token_response_java(
     instance: DescribeDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_delegation_token_v1_request.py
+++ b/tests/generated/test_describe_delegation_token_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_describe_delegation_token_owner: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenOwner))
 @settings(max_examples=1)
 def test_describe_delegation_token_owner_roundtrip(
@@ -38,6 +40,7 @@ read_describe_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenRequest))
 @settings(max_examples=1)
 def test_describe_delegation_token_request_roundtrip(
@@ -51,6 +54,7 @@ def test_describe_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeDelegationTokenRequest))
 def test_describe_delegation_token_request_java(
     instance: DescribeDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_delegation_token_v1_response.py
+++ b/tests/generated/test_describe_delegation_token_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -23,6 +24,7 @@ read_described_delegation_token_renewer: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedDelegationTokenRenewer))
 @settings(max_examples=1)
 def test_described_delegation_token_renewer_roundtrip(
@@ -39,6 +41,7 @@ def test_described_delegation_token_renewer_roundtrip(
 read_described_delegation_token: Final = entity_reader(DescribedDelegationToken)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedDelegationToken))
 @settings(max_examples=1)
 def test_described_delegation_token_roundtrip(
@@ -57,6 +60,7 @@ read_describe_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenResponse))
 @settings(max_examples=1)
 def test_describe_delegation_token_response_roundtrip(
@@ -70,6 +74,7 @@ def test_describe_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeDelegationTokenResponse))
 def test_describe_delegation_token_response_java(
     instance: DescribeDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_delegation_token_v2_request.py
+++ b/tests/generated/test_describe_delegation_token_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_describe_delegation_token_owner: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenOwner))
 @settings(max_examples=1)
 def test_describe_delegation_token_owner_roundtrip(
@@ -38,6 +40,7 @@ read_describe_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenRequest))
 @settings(max_examples=1)
 def test_describe_delegation_token_request_roundtrip(
@@ -51,6 +54,7 @@ def test_describe_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeDelegationTokenRequest))
 def test_describe_delegation_token_request_java(
     instance: DescribeDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_delegation_token_v2_response.py
+++ b/tests/generated/test_describe_delegation_token_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -23,6 +24,7 @@ read_described_delegation_token_renewer: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedDelegationTokenRenewer))
 @settings(max_examples=1)
 def test_described_delegation_token_renewer_roundtrip(
@@ -39,6 +41,7 @@ def test_described_delegation_token_renewer_roundtrip(
 read_described_delegation_token: Final = entity_reader(DescribedDelegationToken)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedDelegationToken))
 @settings(max_examples=1)
 def test_described_delegation_token_roundtrip(
@@ -57,6 +60,7 @@ read_describe_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenResponse))
 @settings(max_examples=1)
 def test_describe_delegation_token_response_roundtrip(
@@ -70,6 +74,7 @@ def test_describe_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeDelegationTokenResponse))
 def test_describe_delegation_token_response_java(
     instance: DescribeDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_delegation_token_v3_request.py
+++ b/tests/generated/test_describe_delegation_token_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_describe_delegation_token_owner: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenOwner))
 @settings(max_examples=1)
 def test_describe_delegation_token_owner_roundtrip(
@@ -38,6 +40,7 @@ read_describe_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenRequest))
 @settings(max_examples=1)
 def test_describe_delegation_token_request_roundtrip(
@@ -51,6 +54,7 @@ def test_describe_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeDelegationTokenRequest))
 def test_describe_delegation_token_request_java(
     instance: DescribeDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_delegation_token_v3_response.py
+++ b/tests/generated/test_describe_delegation_token_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -23,6 +24,7 @@ read_described_delegation_token_renewer: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedDelegationTokenRenewer))
 @settings(max_examples=1)
 def test_described_delegation_token_renewer_roundtrip(
@@ -39,6 +41,7 @@ def test_described_delegation_token_renewer_roundtrip(
 read_described_delegation_token: Final = entity_reader(DescribedDelegationToken)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedDelegationToken))
 @settings(max_examples=1)
 def test_described_delegation_token_roundtrip(
@@ -57,6 +60,7 @@ read_describe_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeDelegationTokenResponse))
 @settings(max_examples=1)
 def test_describe_delegation_token_response_roundtrip(
@@ -70,6 +74,7 @@ def test_describe_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeDelegationTokenResponse))
 def test_describe_delegation_token_response_java(
     instance: DescribeDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v0_request.py
+++ b/tests/generated/test_describe_groups_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_groups_request: Final = entity_reader(DescribeGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsRequest))
 @settings(max_examples=1)
 def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsRequest))
 def test_describe_groups_request_java(
     instance: DescribeGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v0_response.py
+++ b/tests/generated/test_describe_groups_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_described_group_member: Final = entity_reader(DescribedGroupMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroupMember))
 @settings(max_examples=1)
 def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> None:
@@ -31,6 +33,7 @@ def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> Non
 read_described_group: Final = entity_reader(DescribedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroup))
 @settings(max_examples=1)
 def test_described_group_roundtrip(instance: DescribedGroup) -> None:
@@ -45,6 +48,7 @@ def test_described_group_roundtrip(instance: DescribedGroup) -> None:
 read_describe_groups_response: Final = entity_reader(DescribeGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsResponse))
 @settings(max_examples=1)
 def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsResponse))
 def test_describe_groups_response_java(
     instance: DescribeGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v1_request.py
+++ b/tests/generated/test_describe_groups_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_groups_request: Final = entity_reader(DescribeGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsRequest))
 @settings(max_examples=1)
 def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsRequest))
 def test_describe_groups_request_java(
     instance: DescribeGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v1_response.py
+++ b/tests/generated/test_describe_groups_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_described_group_member: Final = entity_reader(DescribedGroupMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroupMember))
 @settings(max_examples=1)
 def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> None:
@@ -31,6 +33,7 @@ def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> Non
 read_described_group: Final = entity_reader(DescribedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroup))
 @settings(max_examples=1)
 def test_described_group_roundtrip(instance: DescribedGroup) -> None:
@@ -45,6 +48,7 @@ def test_described_group_roundtrip(instance: DescribedGroup) -> None:
 read_describe_groups_response: Final = entity_reader(DescribeGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsResponse))
 @settings(max_examples=1)
 def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsResponse))
 def test_describe_groups_response_java(
     instance: DescribeGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v2_request.py
+++ b/tests/generated/test_describe_groups_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_groups_request: Final = entity_reader(DescribeGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsRequest))
 @settings(max_examples=1)
 def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsRequest))
 def test_describe_groups_request_java(
     instance: DescribeGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v2_response.py
+++ b/tests/generated/test_describe_groups_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_described_group_member: Final = entity_reader(DescribedGroupMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroupMember))
 @settings(max_examples=1)
 def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> None:
@@ -31,6 +33,7 @@ def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> Non
 read_described_group: Final = entity_reader(DescribedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroup))
 @settings(max_examples=1)
 def test_described_group_roundtrip(instance: DescribedGroup) -> None:
@@ -45,6 +48,7 @@ def test_described_group_roundtrip(instance: DescribedGroup) -> None:
 read_describe_groups_response: Final = entity_reader(DescribeGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsResponse))
 @settings(max_examples=1)
 def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsResponse))
 def test_describe_groups_response_java(
     instance: DescribeGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v3_request.py
+++ b/tests/generated/test_describe_groups_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_groups_request: Final = entity_reader(DescribeGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsRequest))
 @settings(max_examples=1)
 def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsRequest))
 def test_describe_groups_request_java(
     instance: DescribeGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v3_response.py
+++ b/tests/generated/test_describe_groups_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_described_group_member: Final = entity_reader(DescribedGroupMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroupMember))
 @settings(max_examples=1)
 def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> None:
@@ -31,6 +33,7 @@ def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> Non
 read_described_group: Final = entity_reader(DescribedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroup))
 @settings(max_examples=1)
 def test_described_group_roundtrip(instance: DescribedGroup) -> None:
@@ -45,6 +48,7 @@ def test_described_group_roundtrip(instance: DescribedGroup) -> None:
 read_describe_groups_response: Final = entity_reader(DescribeGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsResponse))
 @settings(max_examples=1)
 def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsResponse))
 def test_describe_groups_response_java(
     instance: DescribeGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v4_request.py
+++ b/tests/generated/test_describe_groups_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_groups_request: Final = entity_reader(DescribeGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsRequest))
 @settings(max_examples=1)
 def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsRequest))
 def test_describe_groups_request_java(
     instance: DescribeGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v4_response.py
+++ b/tests/generated/test_describe_groups_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_described_group_member: Final = entity_reader(DescribedGroupMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroupMember))
 @settings(max_examples=1)
 def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> None:
@@ -31,6 +33,7 @@ def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> Non
 read_described_group: Final = entity_reader(DescribedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroup))
 @settings(max_examples=1)
 def test_described_group_roundtrip(instance: DescribedGroup) -> None:
@@ -45,6 +48,7 @@ def test_described_group_roundtrip(instance: DescribedGroup) -> None:
 read_describe_groups_response: Final = entity_reader(DescribeGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsResponse))
 @settings(max_examples=1)
 def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsResponse))
 def test_describe_groups_response_java(
     instance: DescribeGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v5_request.py
+++ b/tests/generated/test_describe_groups_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_groups_request: Final = entity_reader(DescribeGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsRequest))
 @settings(max_examples=1)
 def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_describe_groups_request_roundtrip(instance: DescribeGroupsRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsRequest))
 def test_describe_groups_request_java(
     instance: DescribeGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_groups_v5_response.py
+++ b/tests/generated/test_describe_groups_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_described_group_member: Final = entity_reader(DescribedGroupMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroupMember))
 @settings(max_examples=1)
 def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> None:
@@ -31,6 +33,7 @@ def test_described_group_member_roundtrip(instance: DescribedGroupMember) -> Non
 read_described_group: Final = entity_reader(DescribedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribedGroup))
 @settings(max_examples=1)
 def test_described_group_roundtrip(instance: DescribedGroup) -> None:
@@ -45,6 +48,7 @@ def test_described_group_roundtrip(instance: DescribedGroup) -> None:
 read_describe_groups_response: Final = entity_reader(DescribeGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeGroupsResponse))
 @settings(max_examples=1)
 def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) -> None:
@@ -56,6 +60,7 @@ def test_describe_groups_response_roundtrip(instance: DescribeGroupsResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeGroupsResponse))
 def test_describe_groups_response_java(
     instance: DescribeGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v0_request.py
+++ b/tests/generated/test_describe_log_dirs_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describable_log_dir_topic: Final = entity_reader(DescribableLogDirTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribableLogDirTopic))
 @settings(max_examples=1)
 def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -> None:
@@ -30,6 +32,7 @@ def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -
 read_describe_log_dirs_request: Final = entity_reader(DescribeLogDirsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsRequest))
 @settings(max_examples=1)
 def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsRequest))
 def test_describe_log_dirs_request_java(
     instance: DescribeLogDirsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v0_response.py
+++ b/tests/generated/test_describe_log_dirs_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_log_dirs_partition: Final = entity_reader(DescribeLogDirsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsPartition))
 @settings(max_examples=1)
 def test_describe_log_dirs_partition_roundtrip(
@@ -34,6 +36,7 @@ def test_describe_log_dirs_partition_roundtrip(
 read_describe_log_dirs_topic: Final = entity_reader(DescribeLogDirsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsTopic))
 @settings(max_examples=1)
 def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> None:
@@ -48,6 +51,7 @@ def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> No
 read_describe_log_dirs_result: Final = entity_reader(DescribeLogDirsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResult))
 @settings(max_examples=1)
 def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> None:
@@ -62,6 +66,7 @@ def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> 
 read_describe_log_dirs_response: Final = entity_reader(DescribeLogDirsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResponse))
 @settings(max_examples=1)
 def test_describe_log_dirs_response_roundtrip(
@@ -75,6 +80,7 @@ def test_describe_log_dirs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsResponse))
 def test_describe_log_dirs_response_java(
     instance: DescribeLogDirsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v1_request.py
+++ b/tests/generated/test_describe_log_dirs_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describable_log_dir_topic: Final = entity_reader(DescribableLogDirTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribableLogDirTopic))
 @settings(max_examples=1)
 def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -> None:
@@ -30,6 +32,7 @@ def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -
 read_describe_log_dirs_request: Final = entity_reader(DescribeLogDirsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsRequest))
 @settings(max_examples=1)
 def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsRequest))
 def test_describe_log_dirs_request_java(
     instance: DescribeLogDirsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v1_response.py
+++ b/tests/generated/test_describe_log_dirs_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_log_dirs_partition: Final = entity_reader(DescribeLogDirsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsPartition))
 @settings(max_examples=1)
 def test_describe_log_dirs_partition_roundtrip(
@@ -34,6 +36,7 @@ def test_describe_log_dirs_partition_roundtrip(
 read_describe_log_dirs_topic: Final = entity_reader(DescribeLogDirsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsTopic))
 @settings(max_examples=1)
 def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> None:
@@ -48,6 +51,7 @@ def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> No
 read_describe_log_dirs_result: Final = entity_reader(DescribeLogDirsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResult))
 @settings(max_examples=1)
 def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> None:
@@ -62,6 +66,7 @@ def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> 
 read_describe_log_dirs_response: Final = entity_reader(DescribeLogDirsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResponse))
 @settings(max_examples=1)
 def test_describe_log_dirs_response_roundtrip(
@@ -75,6 +80,7 @@ def test_describe_log_dirs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsResponse))
 def test_describe_log_dirs_response_java(
     instance: DescribeLogDirsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v2_request.py
+++ b/tests/generated/test_describe_log_dirs_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describable_log_dir_topic: Final = entity_reader(DescribableLogDirTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribableLogDirTopic))
 @settings(max_examples=1)
 def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -> None:
@@ -30,6 +32,7 @@ def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -
 read_describe_log_dirs_request: Final = entity_reader(DescribeLogDirsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsRequest))
 @settings(max_examples=1)
 def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsRequest))
 def test_describe_log_dirs_request_java(
     instance: DescribeLogDirsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v2_response.py
+++ b/tests/generated/test_describe_log_dirs_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_log_dirs_partition: Final = entity_reader(DescribeLogDirsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsPartition))
 @settings(max_examples=1)
 def test_describe_log_dirs_partition_roundtrip(
@@ -34,6 +36,7 @@ def test_describe_log_dirs_partition_roundtrip(
 read_describe_log_dirs_topic: Final = entity_reader(DescribeLogDirsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsTopic))
 @settings(max_examples=1)
 def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> None:
@@ -48,6 +51,7 @@ def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> No
 read_describe_log_dirs_result: Final = entity_reader(DescribeLogDirsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResult))
 @settings(max_examples=1)
 def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> None:
@@ -62,6 +66,7 @@ def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> 
 read_describe_log_dirs_response: Final = entity_reader(DescribeLogDirsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResponse))
 @settings(max_examples=1)
 def test_describe_log_dirs_response_roundtrip(
@@ -75,6 +80,7 @@ def test_describe_log_dirs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsResponse))
 def test_describe_log_dirs_response_java(
     instance: DescribeLogDirsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v3_request.py
+++ b/tests/generated/test_describe_log_dirs_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describable_log_dir_topic: Final = entity_reader(DescribableLogDirTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribableLogDirTopic))
 @settings(max_examples=1)
 def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -> None:
@@ -30,6 +32,7 @@ def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -
 read_describe_log_dirs_request: Final = entity_reader(DescribeLogDirsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsRequest))
 @settings(max_examples=1)
 def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsRequest))
 def test_describe_log_dirs_request_java(
     instance: DescribeLogDirsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v3_response.py
+++ b/tests/generated/test_describe_log_dirs_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_log_dirs_partition: Final = entity_reader(DescribeLogDirsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsPartition))
 @settings(max_examples=1)
 def test_describe_log_dirs_partition_roundtrip(
@@ -34,6 +36,7 @@ def test_describe_log_dirs_partition_roundtrip(
 read_describe_log_dirs_topic: Final = entity_reader(DescribeLogDirsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsTopic))
 @settings(max_examples=1)
 def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> None:
@@ -48,6 +51,7 @@ def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> No
 read_describe_log_dirs_result: Final = entity_reader(DescribeLogDirsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResult))
 @settings(max_examples=1)
 def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> None:
@@ -62,6 +66,7 @@ def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> 
 read_describe_log_dirs_response: Final = entity_reader(DescribeLogDirsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResponse))
 @settings(max_examples=1)
 def test_describe_log_dirs_response_roundtrip(
@@ -75,6 +80,7 @@ def test_describe_log_dirs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsResponse))
 def test_describe_log_dirs_response_java(
     instance: DescribeLogDirsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v4_request.py
+++ b/tests/generated/test_describe_log_dirs_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_describable_log_dir_topic: Final = entity_reader(DescribableLogDirTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribableLogDirTopic))
 @settings(max_examples=1)
 def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -> None:
@@ -30,6 +32,7 @@ def test_describable_log_dir_topic_roundtrip(instance: DescribableLogDirTopic) -
 read_describe_log_dirs_request: Final = entity_reader(DescribeLogDirsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsRequest))
 @settings(max_examples=1)
 def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -> None:
@@ -41,6 +44,7 @@ def test_describe_log_dirs_request_roundtrip(instance: DescribeLogDirsRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsRequest))
 def test_describe_log_dirs_request_java(
     instance: DescribeLogDirsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_log_dirs_v4_response.py
+++ b/tests/generated/test_describe_log_dirs_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_describe_log_dirs_partition: Final = entity_reader(DescribeLogDirsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsPartition))
 @settings(max_examples=1)
 def test_describe_log_dirs_partition_roundtrip(
@@ -34,6 +36,7 @@ def test_describe_log_dirs_partition_roundtrip(
 read_describe_log_dirs_topic: Final = entity_reader(DescribeLogDirsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsTopic))
 @settings(max_examples=1)
 def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> None:
@@ -48,6 +51,7 @@ def test_describe_log_dirs_topic_roundtrip(instance: DescribeLogDirsTopic) -> No
 read_describe_log_dirs_result: Final = entity_reader(DescribeLogDirsResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResult))
 @settings(max_examples=1)
 def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> None:
@@ -62,6 +66,7 @@ def test_describe_log_dirs_result_roundtrip(instance: DescribeLogDirsResult) -> 
 read_describe_log_dirs_response: Final = entity_reader(DescribeLogDirsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeLogDirsResponse))
 @settings(max_examples=1)
 def test_describe_log_dirs_response_roundtrip(
@@ -75,6 +80,7 @@ def test_describe_log_dirs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeLogDirsResponse))
 def test_describe_log_dirs_response_java(
     instance: DescribeLogDirsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_producers_v0_request.py
+++ b/tests/generated/test_describe_producers_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_topic_request: Final = entity_reader(TopicRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicRequest))
 @settings(max_examples=1)
 def test_topic_request_roundtrip(instance: TopicRequest) -> None:
@@ -30,6 +32,7 @@ def test_topic_request_roundtrip(instance: TopicRequest) -> None:
 read_describe_producers_request: Final = entity_reader(DescribeProducersRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeProducersRequest))
 @settings(max_examples=1)
 def test_describe_producers_request_roundtrip(
@@ -43,6 +46,7 @@ def test_describe_producers_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeProducersRequest))
 def test_describe_producers_request_java(
     instance: DescribeProducersRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_producers_v0_response.py
+++ b/tests/generated/test_describe_producers_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_producer_state: Final = entity_reader(ProducerState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProducerState))
 @settings(max_examples=1)
 def test_producer_state_roundtrip(instance: ProducerState) -> None:
@@ -32,6 +34,7 @@ def test_producer_state_roundtrip(instance: ProducerState) -> None:
 read_partition_response: Final = entity_reader(PartitionResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionResponse))
 @settings(max_examples=1)
 def test_partition_response_roundtrip(instance: PartitionResponse) -> None:
@@ -46,6 +49,7 @@ def test_partition_response_roundtrip(instance: PartitionResponse) -> None:
 read_topic_response: Final = entity_reader(TopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicResponse))
 @settings(max_examples=1)
 def test_topic_response_roundtrip(instance: TopicResponse) -> None:
@@ -60,6 +64,7 @@ def test_topic_response_roundtrip(instance: TopicResponse) -> None:
 read_describe_producers_response: Final = entity_reader(DescribeProducersResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeProducersResponse))
 @settings(max_examples=1)
 def test_describe_producers_response_roundtrip(
@@ -73,6 +78,7 @@ def test_describe_producers_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeProducersResponse))
 def test_describe_producers_response_java(
     instance: DescribeProducersResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_quorum_v0_request.py
+++ b/tests/generated/test_describe_quorum_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_describe_quorum_request: Final = entity_reader(DescribeQuorumRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeQuorumRequest))
 @settings(max_examples=1)
 def test_describe_quorum_request_roundtrip(instance: DescribeQuorumRequest) -> None:
@@ -56,6 +60,7 @@ def test_describe_quorum_request_roundtrip(instance: DescribeQuorumRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeQuorumRequest))
 def test_describe_quorum_request_java(
     instance: DescribeQuorumRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_quorum_v0_response.py
+++ b/tests/generated/test_describe_quorum_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_replica_state: Final = entity_reader(ReplicaState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReplicaState))
 @settings(max_examples=1)
 def test_replica_state_roundtrip(instance: ReplicaState) -> None:
@@ -32,6 +34,7 @@ def test_replica_state_roundtrip(instance: ReplicaState) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -46,6 +49,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -60,6 +64,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_describe_quorum_response: Final = entity_reader(DescribeQuorumResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeQuorumResponse))
 @settings(max_examples=1)
 def test_describe_quorum_response_roundtrip(instance: DescribeQuorumResponse) -> None:
@@ -71,6 +76,7 @@ def test_describe_quorum_response_roundtrip(instance: DescribeQuorumResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeQuorumResponse))
 def test_describe_quorum_response_java(
     instance: DescribeQuorumResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_quorum_v1_request.py
+++ b/tests/generated/test_describe_quorum_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_describe_quorum_request: Final = entity_reader(DescribeQuorumRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeQuorumRequest))
 @settings(max_examples=1)
 def test_describe_quorum_request_roundtrip(instance: DescribeQuorumRequest) -> None:
@@ -56,6 +60,7 @@ def test_describe_quorum_request_roundtrip(instance: DescribeQuorumRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeQuorumRequest))
 def test_describe_quorum_request_java(
     instance: DescribeQuorumRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_quorum_v1_response.py
+++ b/tests/generated/test_describe_quorum_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_replica_state: Final = entity_reader(ReplicaState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReplicaState))
 @settings(max_examples=1)
 def test_replica_state_roundtrip(instance: ReplicaState) -> None:
@@ -32,6 +34,7 @@ def test_replica_state_roundtrip(instance: ReplicaState) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -46,6 +49,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -60,6 +64,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_describe_quorum_response: Final = entity_reader(DescribeQuorumResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeQuorumResponse))
 @settings(max_examples=1)
 def test_describe_quorum_response_roundtrip(instance: DescribeQuorumResponse) -> None:
@@ -71,6 +76,7 @@ def test_describe_quorum_response_roundtrip(instance: DescribeQuorumResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeQuorumResponse))
 def test_describe_quorum_response_java(
     instance: DescribeQuorumResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_transactions_v0_request.py
+++ b/tests/generated/test_describe_transactions_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_describe_transactions_request: Final = entity_reader(DescribeTransactionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeTransactionsRequest))
 @settings(max_examples=1)
 def test_describe_transactions_request_roundtrip(
@@ -28,6 +30,7 @@ def test_describe_transactions_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeTransactionsRequest))
 def test_describe_transactions_request_java(
     instance: DescribeTransactionsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_transactions_v0_response.py
+++ b/tests/generated/test_describe_transactions_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -31,6 +33,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_transaction_state: Final = entity_reader(TransactionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TransactionState))
 @settings(max_examples=1)
 def test_transaction_state_roundtrip(instance: TransactionState) -> None:
@@ -45,6 +48,7 @@ def test_transaction_state_roundtrip(instance: TransactionState) -> None:
 read_describe_transactions_response: Final = entity_reader(DescribeTransactionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeTransactionsResponse))
 @settings(max_examples=1)
 def test_describe_transactions_response_roundtrip(
@@ -58,6 +62,7 @@ def test_describe_transactions_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeTransactionsResponse))
 def test_describe_transactions_response_java(
     instance: DescribeTransactionsResponse, java_tester: JavaTester

--- a/tests/generated/test_describe_user_scram_credentials_v0_request.py
+++ b/tests/generated/test_describe_user_scram_credentials_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_user_name: Final = entity_reader(UserName)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UserName))
 @settings(max_examples=1)
 def test_user_name_roundtrip(instance: UserName) -> None:
@@ -34,6 +36,7 @@ read_describe_user_scram_credentials_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeUserScramCredentialsRequest))
 @settings(max_examples=1)
 def test_describe_user_scram_credentials_request_roundtrip(
@@ -47,6 +50,7 @@ def test_describe_user_scram_credentials_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeUserScramCredentialsRequest))
 def test_describe_user_scram_credentials_request_java(
     instance: DescribeUserScramCredentialsRequest, java_tester: JavaTester

--- a/tests/generated/test_describe_user_scram_credentials_v0_response.py
+++ b/tests/generated/test_describe_user_scram_credentials_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ from tests.conftest import setup_buffer
 read_credential_info: Final = entity_reader(CredentialInfo)
 
 
+@pytest.mark.roundtrip
 @given(from_type(CredentialInfo))
 @settings(max_examples=1)
 def test_credential_info_roundtrip(instance: CredentialInfo) -> None:
@@ -37,6 +39,7 @@ read_describe_user_scram_credentials_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeUserScramCredentialsResult))
 @settings(max_examples=1)
 def test_describe_user_scram_credentials_result_roundtrip(
@@ -55,6 +58,7 @@ read_describe_user_scram_credentials_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(DescribeUserScramCredentialsResponse))
 @settings(max_examples=1)
 def test_describe_user_scram_credentials_response_roundtrip(
@@ -68,6 +72,7 @@ def test_describe_user_scram_credentials_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(DescribeUserScramCredentialsResponse))
 def test_describe_user_scram_credentials_response_java(
     instance: DescribeUserScramCredentialsResponse, java_tester: JavaTester

--- a/tests/generated/test_elect_leaders_v0_request.py
+++ b/tests/generated/test_elect_leaders_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_topic_partitions: Final = entity_reader(TopicPartitions)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartitions))
 @settings(max_examples=1)
 def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
@@ -30,6 +32,7 @@ def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
 read_elect_leaders_request: Final = entity_reader(ElectLeadersRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ElectLeadersRequest))
 @settings(max_examples=1)
 def test_elect_leaders_request_roundtrip(instance: ElectLeadersRequest) -> None:
@@ -41,6 +44,7 @@ def test_elect_leaders_request_roundtrip(instance: ElectLeadersRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ElectLeadersRequest))
 def test_elect_leaders_request_java(
     instance: ElectLeadersRequest, java_tester: JavaTester

--- a/tests/generated/test_elect_leaders_v0_response.py
+++ b/tests/generated/test_elect_leaders_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_result: Final = entity_reader(PartitionResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionResult))
 @settings(max_examples=1)
 def test_partition_result_roundtrip(instance: PartitionResult) -> None:
@@ -31,6 +33,7 @@ def test_partition_result_roundtrip(instance: PartitionResult) -> None:
 read_replica_election_result: Final = entity_reader(ReplicaElectionResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReplicaElectionResult))
 @settings(max_examples=1)
 def test_replica_election_result_roundtrip(instance: ReplicaElectionResult) -> None:
@@ -45,6 +48,7 @@ def test_replica_election_result_roundtrip(instance: ReplicaElectionResult) -> N
 read_elect_leaders_response: Final = entity_reader(ElectLeadersResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ElectLeadersResponse))
 @settings(max_examples=1)
 def test_elect_leaders_response_roundtrip(instance: ElectLeadersResponse) -> None:
@@ -56,6 +60,7 @@ def test_elect_leaders_response_roundtrip(instance: ElectLeadersResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ElectLeadersResponse))
 def test_elect_leaders_response_java(
     instance: ElectLeadersResponse, java_tester: JavaTester

--- a/tests/generated/test_elect_leaders_v1_request.py
+++ b/tests/generated/test_elect_leaders_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_topic_partitions: Final = entity_reader(TopicPartitions)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartitions))
 @settings(max_examples=1)
 def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
@@ -30,6 +32,7 @@ def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
 read_elect_leaders_request: Final = entity_reader(ElectLeadersRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ElectLeadersRequest))
 @settings(max_examples=1)
 def test_elect_leaders_request_roundtrip(instance: ElectLeadersRequest) -> None:
@@ -41,6 +44,7 @@ def test_elect_leaders_request_roundtrip(instance: ElectLeadersRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ElectLeadersRequest))
 def test_elect_leaders_request_java(
     instance: ElectLeadersRequest, java_tester: JavaTester

--- a/tests/generated/test_elect_leaders_v1_response.py
+++ b/tests/generated/test_elect_leaders_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_result: Final = entity_reader(PartitionResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionResult))
 @settings(max_examples=1)
 def test_partition_result_roundtrip(instance: PartitionResult) -> None:
@@ -31,6 +33,7 @@ def test_partition_result_roundtrip(instance: PartitionResult) -> None:
 read_replica_election_result: Final = entity_reader(ReplicaElectionResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReplicaElectionResult))
 @settings(max_examples=1)
 def test_replica_election_result_roundtrip(instance: ReplicaElectionResult) -> None:
@@ -45,6 +48,7 @@ def test_replica_election_result_roundtrip(instance: ReplicaElectionResult) -> N
 read_elect_leaders_response: Final = entity_reader(ElectLeadersResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ElectLeadersResponse))
 @settings(max_examples=1)
 def test_elect_leaders_response_roundtrip(instance: ElectLeadersResponse) -> None:
@@ -56,6 +60,7 @@ def test_elect_leaders_response_roundtrip(instance: ElectLeadersResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ElectLeadersResponse))
 def test_elect_leaders_response_java(
     instance: ElectLeadersResponse, java_tester: JavaTester

--- a/tests/generated/test_elect_leaders_v2_request.py
+++ b/tests/generated/test_elect_leaders_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_topic_partitions: Final = entity_reader(TopicPartitions)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicPartitions))
 @settings(max_examples=1)
 def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
@@ -30,6 +32,7 @@ def test_topic_partitions_roundtrip(instance: TopicPartitions) -> None:
 read_elect_leaders_request: Final = entity_reader(ElectLeadersRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ElectLeadersRequest))
 @settings(max_examples=1)
 def test_elect_leaders_request_roundtrip(instance: ElectLeadersRequest) -> None:
@@ -41,6 +44,7 @@ def test_elect_leaders_request_roundtrip(instance: ElectLeadersRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ElectLeadersRequest))
 def test_elect_leaders_request_java(
     instance: ElectLeadersRequest, java_tester: JavaTester

--- a/tests/generated/test_elect_leaders_v2_response.py
+++ b/tests/generated/test_elect_leaders_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_result: Final = entity_reader(PartitionResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionResult))
 @settings(max_examples=1)
 def test_partition_result_roundtrip(instance: PartitionResult) -> None:
@@ -31,6 +33,7 @@ def test_partition_result_roundtrip(instance: PartitionResult) -> None:
 read_replica_election_result: Final = entity_reader(ReplicaElectionResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReplicaElectionResult))
 @settings(max_examples=1)
 def test_replica_election_result_roundtrip(instance: ReplicaElectionResult) -> None:
@@ -45,6 +48,7 @@ def test_replica_election_result_roundtrip(instance: ReplicaElectionResult) -> N
 read_elect_leaders_response: Final = entity_reader(ElectLeadersResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ElectLeadersResponse))
 @settings(max_examples=1)
 def test_elect_leaders_response_roundtrip(instance: ElectLeadersResponse) -> None:
@@ -56,6 +60,7 @@ def test_elect_leaders_response_roundtrip(instance: ElectLeadersResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ElectLeadersResponse))
 def test_elect_leaders_response_java(
     instance: ElectLeadersResponse, java_tester: JavaTester

--- a/tests/generated/test_end_quorum_epoch_v0_request.py
+++ b/tests/generated/test_end_quorum_epoch_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_end_quorum_epoch_request: Final = entity_reader(EndQuorumEpochRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndQuorumEpochRequest))
 @settings(max_examples=1)
 def test_end_quorum_epoch_request_roundtrip(instance: EndQuorumEpochRequest) -> None:
@@ -56,6 +60,7 @@ def test_end_quorum_epoch_request_roundtrip(instance: EndQuorumEpochRequest) -> 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndQuorumEpochRequest))
 def test_end_quorum_epoch_request_java(
     instance: EndQuorumEpochRequest, java_tester: JavaTester

--- a/tests/generated/test_end_quorum_epoch_v0_response.py
+++ b/tests/generated/test_end_quorum_epoch_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_end_quorum_epoch_response: Final = entity_reader(EndQuorumEpochResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndQuorumEpochResponse))
 @settings(max_examples=1)
 def test_end_quorum_epoch_response_roundtrip(instance: EndQuorumEpochResponse) -> None:
@@ -56,6 +60,7 @@ def test_end_quorum_epoch_response_roundtrip(instance: EndQuorumEpochResponse) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndQuorumEpochResponse))
 def test_end_quorum_epoch_response_java(
     instance: EndQuorumEpochResponse, java_tester: JavaTester

--- a/tests/generated/test_end_txn_v0_request.py
+++ b/tests/generated/test_end_txn_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_end_txn_request: Final = entity_reader(EndTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndTxnRequest))
 @settings(max_examples=1)
 def test_end_txn_request_roundtrip(instance: EndTxnRequest) -> None:
@@ -26,6 +28,7 @@ def test_end_txn_request_roundtrip(instance: EndTxnRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndTxnRequest))
 def test_end_txn_request_java(instance: EndTxnRequest, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_end_txn_v0_response.py
+++ b/tests/generated/test_end_txn_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_end_txn_response: Final = entity_reader(EndTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndTxnResponse))
 @settings(max_examples=1)
 def test_end_txn_response_roundtrip(instance: EndTxnResponse) -> None:
@@ -26,6 +28,7 @@ def test_end_txn_response_roundtrip(instance: EndTxnResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndTxnResponse))
 def test_end_txn_response_java(
     instance: EndTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_end_txn_v1_request.py
+++ b/tests/generated/test_end_txn_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_end_txn_request: Final = entity_reader(EndTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndTxnRequest))
 @settings(max_examples=1)
 def test_end_txn_request_roundtrip(instance: EndTxnRequest) -> None:
@@ -26,6 +28,7 @@ def test_end_txn_request_roundtrip(instance: EndTxnRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndTxnRequest))
 def test_end_txn_request_java(instance: EndTxnRequest, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_end_txn_v1_response.py
+++ b/tests/generated/test_end_txn_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_end_txn_response: Final = entity_reader(EndTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndTxnResponse))
 @settings(max_examples=1)
 def test_end_txn_response_roundtrip(instance: EndTxnResponse) -> None:
@@ -26,6 +28,7 @@ def test_end_txn_response_roundtrip(instance: EndTxnResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndTxnResponse))
 def test_end_txn_response_java(
     instance: EndTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_end_txn_v2_request.py
+++ b/tests/generated/test_end_txn_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_end_txn_request: Final = entity_reader(EndTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndTxnRequest))
 @settings(max_examples=1)
 def test_end_txn_request_roundtrip(instance: EndTxnRequest) -> None:
@@ -26,6 +28,7 @@ def test_end_txn_request_roundtrip(instance: EndTxnRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndTxnRequest))
 def test_end_txn_request_java(instance: EndTxnRequest, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_end_txn_v2_response.py
+++ b/tests/generated/test_end_txn_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_end_txn_response: Final = entity_reader(EndTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndTxnResponse))
 @settings(max_examples=1)
 def test_end_txn_response_roundtrip(instance: EndTxnResponse) -> None:
@@ -26,6 +28,7 @@ def test_end_txn_response_roundtrip(instance: EndTxnResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndTxnResponse))
 def test_end_txn_response_java(
     instance: EndTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_end_txn_v3_request.py
+++ b/tests/generated/test_end_txn_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_end_txn_request: Final = entity_reader(EndTxnRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndTxnRequest))
 @settings(max_examples=1)
 def test_end_txn_request_roundtrip(instance: EndTxnRequest) -> None:
@@ -26,6 +28,7 @@ def test_end_txn_request_roundtrip(instance: EndTxnRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndTxnRequest))
 def test_end_txn_request_java(instance: EndTxnRequest, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_end_txn_v3_response.py
+++ b/tests/generated/test_end_txn_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_end_txn_response: Final = entity_reader(EndTxnResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EndTxnResponse))
 @settings(max_examples=1)
 def test_end_txn_response_roundtrip(instance: EndTxnResponse) -> None:
@@ -26,6 +28,7 @@ def test_end_txn_response_roundtrip(instance: EndTxnResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EndTxnResponse))
 def test_end_txn_response_java(
     instance: EndTxnResponse, java_tester: JavaTester

--- a/tests/generated/test_envelope_v0_request.py
+++ b/tests/generated/test_envelope_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_envelope_request: Final = entity_reader(EnvelopeRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EnvelopeRequest))
 @settings(max_examples=1)
 def test_envelope_request_roundtrip(instance: EnvelopeRequest) -> None:
@@ -26,6 +28,7 @@ def test_envelope_request_roundtrip(instance: EnvelopeRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EnvelopeRequest))
 def test_envelope_request_java(
     instance: EnvelopeRequest, java_tester: JavaTester

--- a/tests/generated/test_envelope_v0_response.py
+++ b/tests/generated/test_envelope_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_envelope_response: Final = entity_reader(EnvelopeResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EnvelopeResponse))
 @settings(max_examples=1)
 def test_envelope_response_roundtrip(instance: EnvelopeResponse) -> None:
@@ -26,6 +28,7 @@ def test_envelope_response_roundtrip(instance: EnvelopeResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(EnvelopeResponse))
 def test_envelope_response_java(
     instance: EnvelopeResponse, java_tester: JavaTester

--- a/tests/generated/test_expire_delegation_token_v0_request.py
+++ b/tests/generated/test_expire_delegation_token_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_expire_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ExpireDelegationTokenRequest))
 @settings(max_examples=1)
 def test_expire_delegation_token_request_roundtrip(
@@ -30,6 +32,7 @@ def test_expire_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ExpireDelegationTokenRequest))
 def test_expire_delegation_token_request_java(
     instance: ExpireDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_expire_delegation_token_v0_response.py
+++ b/tests/generated/test_expire_delegation_token_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_expire_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ExpireDelegationTokenResponse))
 @settings(max_examples=1)
 def test_expire_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_expire_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ExpireDelegationTokenResponse))
 def test_expire_delegation_token_response_java(
     instance: ExpireDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_expire_delegation_token_v1_request.py
+++ b/tests/generated/test_expire_delegation_token_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_expire_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ExpireDelegationTokenRequest))
 @settings(max_examples=1)
 def test_expire_delegation_token_request_roundtrip(
@@ -30,6 +32,7 @@ def test_expire_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ExpireDelegationTokenRequest))
 def test_expire_delegation_token_request_java(
     instance: ExpireDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_expire_delegation_token_v1_response.py
+++ b/tests/generated/test_expire_delegation_token_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_expire_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ExpireDelegationTokenResponse))
 @settings(max_examples=1)
 def test_expire_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_expire_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ExpireDelegationTokenResponse))
 def test_expire_delegation_token_response_java(
     instance: ExpireDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_expire_delegation_token_v2_request.py
+++ b/tests/generated/test_expire_delegation_token_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_expire_delegation_token_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ExpireDelegationTokenRequest))
 @settings(max_examples=1)
 def test_expire_delegation_token_request_roundtrip(
@@ -30,6 +32,7 @@ def test_expire_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ExpireDelegationTokenRequest))
 def test_expire_delegation_token_request_java(
     instance: ExpireDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_expire_delegation_token_v2_response.py
+++ b/tests/generated/test_expire_delegation_token_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_expire_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ExpireDelegationTokenResponse))
 @settings(max_examples=1)
 def test_expire_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_expire_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ExpireDelegationTokenResponse))
 def test_expire_delegation_token_response_java(
     instance: ExpireDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_fetch_snapshot_v0_request.py
+++ b/tests/generated/test_fetch_snapshot_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_snapshot_id: Final = entity_reader(SnapshotId)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SnapshotId))
 @settings(max_examples=1)
 def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
@@ -32,6 +34,7 @@ def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
 read_partition_snapshot: Final = entity_reader(PartitionSnapshot)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionSnapshot))
 @settings(max_examples=1)
 def test_partition_snapshot_roundtrip(instance: PartitionSnapshot) -> None:
@@ -46,6 +49,7 @@ def test_partition_snapshot_roundtrip(instance: PartitionSnapshot) -> None:
 read_topic_snapshot: Final = entity_reader(TopicSnapshot)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicSnapshot))
 @settings(max_examples=1)
 def test_topic_snapshot_roundtrip(instance: TopicSnapshot) -> None:
@@ -60,6 +64,7 @@ def test_topic_snapshot_roundtrip(instance: TopicSnapshot) -> None:
 read_fetch_snapshot_request: Final = entity_reader(FetchSnapshotRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchSnapshotRequest))
 @settings(max_examples=1)
 def test_fetch_snapshot_request_roundtrip(instance: FetchSnapshotRequest) -> None:
@@ -71,6 +76,7 @@ def test_fetch_snapshot_request_roundtrip(instance: FetchSnapshotRequest) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FetchSnapshotRequest))
 def test_fetch_snapshot_request_java(
     instance: FetchSnapshotRequest, java_tester: JavaTester

--- a/tests/generated/test_fetch_snapshot_v0_response.py
+++ b/tests/generated/test_fetch_snapshot_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_snapshot_id: Final = entity_reader(SnapshotId)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SnapshotId))
 @settings(max_examples=1)
 def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
@@ -32,6 +34,7 @@ def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
 read_leader_id_and_epoch: Final = entity_reader(LeaderIdAndEpoch)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderIdAndEpoch))
 @settings(max_examples=1)
 def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
@@ -46,6 +49,7 @@ def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
 read_partition_snapshot: Final = entity_reader(PartitionSnapshot)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionSnapshot))
 @settings(max_examples=1)
 def test_partition_snapshot_roundtrip(instance: PartitionSnapshot) -> None:
@@ -60,6 +64,7 @@ def test_partition_snapshot_roundtrip(instance: PartitionSnapshot) -> None:
 read_topic_snapshot: Final = entity_reader(TopicSnapshot)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicSnapshot))
 @settings(max_examples=1)
 def test_topic_snapshot_roundtrip(instance: TopicSnapshot) -> None:
@@ -74,6 +79,7 @@ def test_topic_snapshot_roundtrip(instance: TopicSnapshot) -> None:
 read_fetch_snapshot_response: Final = entity_reader(FetchSnapshotResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchSnapshotResponse))
 @settings(max_examples=1)
 def test_fetch_snapshot_response_roundtrip(instance: FetchSnapshotResponse) -> None:

--- a/tests/generated/test_fetch_v0_request.py
+++ b/tests/generated/test_fetch_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -30,6 +32,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -44,6 +47,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v0_response.py
+++ b/tests/generated/test_fetch_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -30,6 +32,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -44,6 +47,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v10_request.py
+++ b/tests/generated/test_fetch_v10_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -31,6 +33,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -45,6 +48,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -59,6 +63,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v10_response.py
+++ b/tests/generated/test_fetch_v10_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -31,6 +33,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -45,6 +48,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -59,6 +63,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v11_request.py
+++ b/tests/generated/test_fetch_v11_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -31,6 +33,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -45,6 +48,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -59,6 +63,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v11_response.py
+++ b/tests/generated/test_fetch_v11_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -31,6 +33,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -45,6 +48,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -59,6 +63,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v12_request.py
+++ b/tests/generated/test_fetch_v12_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -31,6 +33,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -45,6 +48,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -59,6 +63,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v12_response.py
+++ b/tests/generated/test_fetch_v12_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -34,6 +36,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_leader_id_and_epoch: Final = entity_reader(LeaderIdAndEpoch)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderIdAndEpoch))
 @settings(max_examples=1)
 def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
@@ -48,6 +51,7 @@ def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
 read_snapshot_id: Final = entity_reader(SnapshotId)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SnapshotId))
 @settings(max_examples=1)
 def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
@@ -62,6 +66,7 @@ def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -76,6 +81,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -90,6 +96,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -104,6 +111,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v13_request.py
+++ b/tests/generated/test_fetch_v13_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -31,6 +33,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -45,6 +48,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -59,6 +63,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v13_response.py
+++ b/tests/generated/test_fetch_v13_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -34,6 +36,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_leader_id_and_epoch: Final = entity_reader(LeaderIdAndEpoch)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderIdAndEpoch))
 @settings(max_examples=1)
 def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
@@ -48,6 +51,7 @@ def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
 read_snapshot_id: Final = entity_reader(SnapshotId)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SnapshotId))
 @settings(max_examples=1)
 def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
@@ -62,6 +66,7 @@ def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -76,6 +81,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -90,6 +96,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -104,6 +111,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v14_request.py
+++ b/tests/generated/test_fetch_v14_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -31,6 +33,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -45,6 +48,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -59,6 +63,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v14_response.py
+++ b/tests/generated/test_fetch_v14_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -34,6 +36,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_leader_id_and_epoch: Final = entity_reader(LeaderIdAndEpoch)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderIdAndEpoch))
 @settings(max_examples=1)
 def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
@@ -48,6 +51,7 @@ def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
 read_snapshot_id: Final = entity_reader(SnapshotId)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SnapshotId))
 @settings(max_examples=1)
 def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
@@ -62,6 +66,7 @@ def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -76,6 +81,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -90,6 +96,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -104,6 +111,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v15_request.py
+++ b/tests/generated/test_fetch_v15_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_replica_state: Final = entity_reader(ReplicaState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ReplicaState))
 @settings(max_examples=1)
 def test_replica_state_roundtrip(instance: ReplicaState) -> None:
@@ -32,6 +34,7 @@ def test_replica_state_roundtrip(instance: ReplicaState) -> None:
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -46,6 +49,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -60,6 +64,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -74,6 +79,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v15_response.py
+++ b/tests/generated/test_fetch_v15_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -34,6 +36,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_leader_id_and_epoch: Final = entity_reader(LeaderIdAndEpoch)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderIdAndEpoch))
 @settings(max_examples=1)
 def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
@@ -48,6 +51,7 @@ def test_leader_id_and_epoch_roundtrip(instance: LeaderIdAndEpoch) -> None:
 read_snapshot_id: Final = entity_reader(SnapshotId)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SnapshotId))
 @settings(max_examples=1)
 def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
@@ -62,6 +66,7 @@ def test_snapshot_id_roundtrip(instance: SnapshotId) -> None:
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -76,6 +81,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -90,6 +96,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -104,6 +111,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v1_request.py
+++ b/tests/generated/test_fetch_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -30,6 +32,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -44,6 +47,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v1_response.py
+++ b/tests/generated/test_fetch_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -30,6 +32,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -44,6 +47,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v2_request.py
+++ b/tests/generated/test_fetch_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -30,6 +32,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -44,6 +47,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v2_response.py
+++ b/tests/generated/test_fetch_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -30,6 +32,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -44,6 +47,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v3_request.py
+++ b/tests/generated/test_fetch_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -30,6 +32,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -44,6 +47,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v3_response.py
+++ b/tests/generated/test_fetch_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -30,6 +32,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -44,6 +47,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v4_request.py
+++ b/tests/generated/test_fetch_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -30,6 +32,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -44,6 +47,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v4_response.py
+++ b/tests/generated/test_fetch_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -31,6 +33,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -45,6 +48,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -59,6 +63,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v5_request.py
+++ b/tests/generated/test_fetch_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -30,6 +32,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -44,6 +47,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v5_response.py
+++ b/tests/generated/test_fetch_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -31,6 +33,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -45,6 +48,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -59,6 +63,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v6_request.py
+++ b/tests/generated/test_fetch_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -30,6 +32,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -44,6 +47,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v6_response.py
+++ b/tests/generated/test_fetch_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -31,6 +33,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -45,6 +48,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -59,6 +63,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v7_request.py
+++ b/tests/generated/test_fetch_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -31,6 +33,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -45,6 +48,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -59,6 +63,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v7_response.py
+++ b/tests/generated/test_fetch_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -31,6 +33,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -45,6 +48,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -59,6 +63,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v8_request.py
+++ b/tests/generated/test_fetch_v8_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -31,6 +33,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -45,6 +48,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -59,6 +63,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v8_response.py
+++ b/tests/generated/test_fetch_v8_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -31,6 +33,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -45,6 +48,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -59,6 +63,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_fetch_v9_request.py
+++ b/tests/generated/test_fetch_v9_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_fetch_partition: Final = entity_reader(FetchPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchPartition))
 @settings(max_examples=1)
 def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
@@ -31,6 +33,7 @@ def test_fetch_partition_roundtrip(instance: FetchPartition) -> None:
 read_fetch_topic: Final = entity_reader(FetchTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchTopic))
 @settings(max_examples=1)
 def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
@@ -45,6 +48,7 @@ def test_fetch_topic_roundtrip(instance: FetchTopic) -> None:
 read_forgotten_topic: Final = entity_reader(ForgottenTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ForgottenTopic))
 @settings(max_examples=1)
 def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
@@ -59,6 +63,7 @@ def test_forgotten_topic_roundtrip(instance: ForgottenTopic) -> None:
 read_fetch_request: Final = entity_reader(FetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchRequest))
 @settings(max_examples=1)
 def test_fetch_request_roundtrip(instance: FetchRequest) -> None:

--- a/tests/generated/test_fetch_v9_response.py
+++ b/tests/generated/test_fetch_v9_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_aborted_transaction: Final = entity_reader(AbortedTransaction)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AbortedTransaction))
 @settings(max_examples=1)
 def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
@@ -31,6 +33,7 @@ def test_aborted_transaction_roundtrip(instance: AbortedTransaction) -> None:
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -45,6 +48,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_fetchable_topic_response: Final = entity_reader(FetchableTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchableTopicResponse))
 @settings(max_examples=1)
 def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) -> None:
@@ -59,6 +63,7 @@ def test_fetchable_topic_response_roundtrip(instance: FetchableTopicResponse) ->
 read_fetch_response: Final = entity_reader(FetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FetchResponse))
 @settings(max_examples=1)
 def test_fetch_response_roundtrip(instance: FetchResponse) -> None:

--- a/tests/generated/test_find_coordinator_v0_request.py
+++ b/tests/generated/test_find_coordinator_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_request: Final = entity_reader(FindCoordinatorRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorRequest))
 @settings(max_examples=1)
 def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorRequest))
 def test_find_coordinator_request_java(
     instance: FindCoordinatorRequest, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v0_response.py
+++ b/tests/generated/test_find_coordinator_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_response: Final = entity_reader(FindCoordinatorResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorResponse))
 @settings(max_examples=1)
 def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorResponse))
 def test_find_coordinator_response_java(
     instance: FindCoordinatorResponse, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v1_request.py
+++ b/tests/generated/test_find_coordinator_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_request: Final = entity_reader(FindCoordinatorRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorRequest))
 @settings(max_examples=1)
 def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorRequest))
 def test_find_coordinator_request_java(
     instance: FindCoordinatorRequest, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v1_response.py
+++ b/tests/generated/test_find_coordinator_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_response: Final = entity_reader(FindCoordinatorResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorResponse))
 @settings(max_examples=1)
 def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorResponse))
 def test_find_coordinator_response_java(
     instance: FindCoordinatorResponse, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v2_request.py
+++ b/tests/generated/test_find_coordinator_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_request: Final = entity_reader(FindCoordinatorRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorRequest))
 @settings(max_examples=1)
 def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorRequest))
 def test_find_coordinator_request_java(
     instance: FindCoordinatorRequest, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v2_response.py
+++ b/tests/generated/test_find_coordinator_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_response: Final = entity_reader(FindCoordinatorResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorResponse))
 @settings(max_examples=1)
 def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorResponse))
 def test_find_coordinator_response_java(
     instance: FindCoordinatorResponse, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v3_request.py
+++ b/tests/generated/test_find_coordinator_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_request: Final = entity_reader(FindCoordinatorRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorRequest))
 @settings(max_examples=1)
 def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorRequest))
 def test_find_coordinator_request_java(
     instance: FindCoordinatorRequest, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v3_response.py
+++ b/tests/generated/test_find_coordinator_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_response: Final = entity_reader(FindCoordinatorResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorResponse))
 @settings(max_examples=1)
 def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorResponse))
 def test_find_coordinator_response_java(
     instance: FindCoordinatorResponse, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v4_request.py
+++ b/tests/generated/test_find_coordinator_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_find_coordinator_request: Final = entity_reader(FindCoordinatorRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorRequest))
 @settings(max_examples=1)
 def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) -> None:
@@ -26,6 +28,7 @@ def test_find_coordinator_request_roundtrip(instance: FindCoordinatorRequest) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorRequest))
 def test_find_coordinator_request_java(
     instance: FindCoordinatorRequest, java_tester: JavaTester

--- a/tests/generated/test_find_coordinator_v4_response.py
+++ b/tests/generated/test_find_coordinator_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_coordinator: Final = entity_reader(Coordinator)
 
 
+@pytest.mark.roundtrip
 @given(from_type(Coordinator))
 @settings(max_examples=1)
 def test_coordinator_roundtrip(instance: Coordinator) -> None:
@@ -30,6 +32,7 @@ def test_coordinator_roundtrip(instance: Coordinator) -> None:
 read_find_coordinator_response: Final = entity_reader(FindCoordinatorResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FindCoordinatorResponse))
 @settings(max_examples=1)
 def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) -> None:
@@ -41,6 +44,7 @@ def test_find_coordinator_response_roundtrip(instance: FindCoordinatorResponse) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(FindCoordinatorResponse))
 def test_find_coordinator_response_java(
     instance: FindCoordinatorResponse, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v0_request.py
+++ b/tests/generated/test_heartbeat_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_request: Final = entity_reader(HeartbeatRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatRequest))
 @settings(max_examples=1)
 def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatRequest))
 def test_heartbeat_request_java(
     instance: HeartbeatRequest, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v0_response.py
+++ b/tests/generated/test_heartbeat_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_response: Final = entity_reader(HeartbeatResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatResponse))
 @settings(max_examples=1)
 def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatResponse))
 def test_heartbeat_response_java(
     instance: HeartbeatResponse, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v1_request.py
+++ b/tests/generated/test_heartbeat_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_request: Final = entity_reader(HeartbeatRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatRequest))
 @settings(max_examples=1)
 def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatRequest))
 def test_heartbeat_request_java(
     instance: HeartbeatRequest, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v1_response.py
+++ b/tests/generated/test_heartbeat_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_response: Final = entity_reader(HeartbeatResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatResponse))
 @settings(max_examples=1)
 def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatResponse))
 def test_heartbeat_response_java(
     instance: HeartbeatResponse, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v2_request.py
+++ b/tests/generated/test_heartbeat_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_request: Final = entity_reader(HeartbeatRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatRequest))
 @settings(max_examples=1)
 def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatRequest))
 def test_heartbeat_request_java(
     instance: HeartbeatRequest, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v2_response.py
+++ b/tests/generated/test_heartbeat_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_response: Final = entity_reader(HeartbeatResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatResponse))
 @settings(max_examples=1)
 def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatResponse))
 def test_heartbeat_response_java(
     instance: HeartbeatResponse, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v3_request.py
+++ b/tests/generated/test_heartbeat_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_request: Final = entity_reader(HeartbeatRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatRequest))
 @settings(max_examples=1)
 def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatRequest))
 def test_heartbeat_request_java(
     instance: HeartbeatRequest, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v3_response.py
+++ b/tests/generated/test_heartbeat_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_response: Final = entity_reader(HeartbeatResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatResponse))
 @settings(max_examples=1)
 def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatResponse))
 def test_heartbeat_response_java(
     instance: HeartbeatResponse, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v4_request.py
+++ b/tests/generated/test_heartbeat_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_request: Final = entity_reader(HeartbeatRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatRequest))
 @settings(max_examples=1)
 def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_request_roundtrip(instance: HeartbeatRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatRequest))
 def test_heartbeat_request_java(
     instance: HeartbeatRequest, java_tester: JavaTester

--- a/tests/generated/test_heartbeat_v4_response.py
+++ b/tests/generated/test_heartbeat_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_heartbeat_response: Final = entity_reader(HeartbeatResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(HeartbeatResponse))
 @settings(max_examples=1)
 def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
@@ -26,6 +28,7 @@ def test_heartbeat_response_roundtrip(instance: HeartbeatResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(HeartbeatResponse))
 def test_heartbeat_response_java(
     instance: HeartbeatResponse, java_tester: JavaTester

--- a/tests/generated/test_incremental_alter_configs_v0_request.py
+++ b/tests/generated/test_incremental_alter_configs_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ from tests.conftest import setup_buffer
 read_alterable_config: Final = entity_reader(AlterableConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterableConfig))
 @settings(max_examples=1)
 def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
@@ -33,6 +35,7 @@ def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
 read_alter_configs_resource: Final = entity_reader(AlterConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResource))
 @settings(max_examples=1)
 def test_alter_configs_resource_roundtrip(instance: AlterConfigsResource) -> None:
@@ -49,6 +52,7 @@ read_incremental_alter_configs_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(IncrementalAlterConfigsRequest))
 @settings(max_examples=1)
 def test_incremental_alter_configs_request_roundtrip(
@@ -62,6 +66,7 @@ def test_incremental_alter_configs_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(IncrementalAlterConfigsRequest))
 def test_incremental_alter_configs_request_java(
     instance: IncrementalAlterConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_incremental_alter_configs_v0_response.py
+++ b/tests/generated/test_incremental_alter_configs_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -22,6 +23,7 @@ read_alter_configs_resource_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResourceResponse))
 @settings(max_examples=1)
 def test_alter_configs_resource_response_roundtrip(
@@ -40,6 +42,7 @@ read_incremental_alter_configs_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(IncrementalAlterConfigsResponse))
 @settings(max_examples=1)
 def test_incremental_alter_configs_response_roundtrip(
@@ -53,6 +56,7 @@ def test_incremental_alter_configs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(IncrementalAlterConfigsResponse))
 def test_incremental_alter_configs_response_java(
     instance: IncrementalAlterConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_incremental_alter_configs_v1_request.py
+++ b/tests/generated/test_incremental_alter_configs_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ from tests.conftest import setup_buffer
 read_alterable_config: Final = entity_reader(AlterableConfig)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterableConfig))
 @settings(max_examples=1)
 def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
@@ -33,6 +35,7 @@ def test_alterable_config_roundtrip(instance: AlterableConfig) -> None:
 read_alter_configs_resource: Final = entity_reader(AlterConfigsResource)
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResource))
 @settings(max_examples=1)
 def test_alter_configs_resource_roundtrip(instance: AlterConfigsResource) -> None:
@@ -49,6 +52,7 @@ read_incremental_alter_configs_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(IncrementalAlterConfigsRequest))
 @settings(max_examples=1)
 def test_incremental_alter_configs_request_roundtrip(
@@ -62,6 +66,7 @@ def test_incremental_alter_configs_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(IncrementalAlterConfigsRequest))
 def test_incremental_alter_configs_request_java(
     instance: IncrementalAlterConfigsRequest, java_tester: JavaTester

--- a/tests/generated/test_incremental_alter_configs_v1_response.py
+++ b/tests/generated/test_incremental_alter_configs_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -22,6 +23,7 @@ read_alter_configs_resource_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(AlterConfigsResourceResponse))
 @settings(max_examples=1)
 def test_alter_configs_resource_response_roundtrip(
@@ -40,6 +42,7 @@ read_incremental_alter_configs_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(IncrementalAlterConfigsResponse))
 @settings(max_examples=1)
 def test_incremental_alter_configs_response_roundtrip(
@@ -53,6 +56,7 @@ def test_incremental_alter_configs_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(IncrementalAlterConfigsResponse))
 def test_incremental_alter_configs_response_java(
     instance: IncrementalAlterConfigsResponse, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v0_request.py
+++ b/tests/generated/test_init_producer_id_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_request: Final = entity_reader(InitProducerIdRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdRequest))
 @settings(max_examples=1)
 def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdRequest))
 def test_init_producer_id_request_java(
     instance: InitProducerIdRequest, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v0_response.py
+++ b/tests/generated/test_init_producer_id_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_response: Final = entity_reader(InitProducerIdResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdResponse))
 @settings(max_examples=1)
 def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdResponse))
 def test_init_producer_id_response_java(
     instance: InitProducerIdResponse, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v1_request.py
+++ b/tests/generated/test_init_producer_id_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_request: Final = entity_reader(InitProducerIdRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdRequest))
 @settings(max_examples=1)
 def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdRequest))
 def test_init_producer_id_request_java(
     instance: InitProducerIdRequest, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v1_response.py
+++ b/tests/generated/test_init_producer_id_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_response: Final = entity_reader(InitProducerIdResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdResponse))
 @settings(max_examples=1)
 def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdResponse))
 def test_init_producer_id_response_java(
     instance: InitProducerIdResponse, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v2_request.py
+++ b/tests/generated/test_init_producer_id_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_request: Final = entity_reader(InitProducerIdRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdRequest))
 @settings(max_examples=1)
 def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdRequest))
 def test_init_producer_id_request_java(
     instance: InitProducerIdRequest, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v2_response.py
+++ b/tests/generated/test_init_producer_id_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_response: Final = entity_reader(InitProducerIdResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdResponse))
 @settings(max_examples=1)
 def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdResponse))
 def test_init_producer_id_response_java(
     instance: InitProducerIdResponse, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v3_request.py
+++ b/tests/generated/test_init_producer_id_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_request: Final = entity_reader(InitProducerIdRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdRequest))
 @settings(max_examples=1)
 def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdRequest))
 def test_init_producer_id_request_java(
     instance: InitProducerIdRequest, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v3_response.py
+++ b/tests/generated/test_init_producer_id_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_response: Final = entity_reader(InitProducerIdResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdResponse))
 @settings(max_examples=1)
 def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdResponse))
 def test_init_producer_id_response_java(
     instance: InitProducerIdResponse, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v4_request.py
+++ b/tests/generated/test_init_producer_id_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_request: Final = entity_reader(InitProducerIdRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdRequest))
 @settings(max_examples=1)
 def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_request_roundtrip(instance: InitProducerIdRequest) -> 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdRequest))
 def test_init_producer_id_request_java(
     instance: InitProducerIdRequest, java_tester: JavaTester

--- a/tests/generated/test_init_producer_id_v4_response.py
+++ b/tests/generated/test_init_producer_id_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_init_producer_id_response: Final = entity_reader(InitProducerIdResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(InitProducerIdResponse))
 @settings(max_examples=1)
 def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -> None:
@@ -26,6 +28,7 @@ def test_init_producer_id_response_roundtrip(instance: InitProducerIdResponse) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(InitProducerIdResponse))
 def test_init_producer_id_response_java(
     instance: InitProducerIdResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v0_request.py
+++ b/tests/generated/test_join_group_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v0_response.py
+++ b/tests/generated/test_join_group_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v1_request.py
+++ b/tests/generated/test_join_group_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v1_response.py
+++ b/tests/generated/test_join_group_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v2_request.py
+++ b/tests/generated/test_join_group_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v2_response.py
+++ b/tests/generated/test_join_group_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v3_request.py
+++ b/tests/generated/test_join_group_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v3_response.py
+++ b/tests/generated/test_join_group_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v4_request.py
+++ b/tests/generated/test_join_group_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v4_response.py
+++ b/tests/generated/test_join_group_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v5_request.py
+++ b/tests/generated/test_join_group_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v5_response.py
+++ b/tests/generated/test_join_group_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v6_request.py
+++ b/tests/generated/test_join_group_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v6_response.py
+++ b/tests/generated/test_join_group_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v7_request.py
+++ b/tests/generated/test_join_group_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v7_response.py
+++ b/tests/generated/test_join_group_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v8_request.py
+++ b/tests/generated/test_join_group_v8_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v8_response.py
+++ b/tests/generated/test_join_group_v8_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_join_group_v9_request.py
+++ b/tests/generated/test_join_group_v9_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_request_protocol: Final = entity_reader(JoinGroupRequestProtocol)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequestProtocol))
 @settings(max_examples=1)
 def test_join_group_request_protocol_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_request_protocol_roundtrip(
 read_join_group_request: Final = entity_reader(JoinGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupRequest))
 @settings(max_examples=1)
 def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_join_group_request_roundtrip(instance: JoinGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupRequest))
 def test_join_group_request_java(
     instance: JoinGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_join_group_v9_response.py
+++ b/tests/generated/test_join_group_v9_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_join_group_response_member: Final = entity_reader(JoinGroupResponseMember)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponseMember))
 @settings(max_examples=1)
 def test_join_group_response_member_roundtrip(
@@ -32,6 +34,7 @@ def test_join_group_response_member_roundtrip(
 read_join_group_response: Final = entity_reader(JoinGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(JoinGroupResponse))
 @settings(max_examples=1)
 def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
@@ -43,6 +46,7 @@ def test_join_group_response_roundtrip(instance: JoinGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(JoinGroupResponse))
 def test_join_group_response_java(
     instance: JoinGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v0_request.py
+++ b/tests/generated/test_leader_and_isr_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_state: Final = entity_reader(LeaderAndIsrPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionState))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_state_roundtrip(
@@ -33,6 +35,7 @@ def test_leader_and_isr_partition_state_roundtrip(
 read_leader_and_isr_live_leader: Final = entity_reader(LeaderAndIsrLiveLeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrLiveLeader))
 @settings(max_examples=1)
 def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) -> None:
@@ -47,6 +50,7 @@ def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) 
 read_leader_and_isr_request: Final = entity_reader(LeaderAndIsrRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrRequest))
 @settings(max_examples=1)
 def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None:
@@ -58,6 +62,7 @@ def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrRequest))
 def test_leader_and_isr_request_java(
     instance: LeaderAndIsrRequest, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v0_response.py
+++ b/tests/generated/test_leader_and_isr_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_error: Final = entity_reader(LeaderAndIsrPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionError))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_leader_and_isr_partition_error_roundtrip(
 read_leader_and_isr_response: Final = entity_reader(LeaderAndIsrResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrResponse))
 @settings(max_examples=1)
 def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> None:
@@ -43,6 +46,7 @@ def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> No
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrResponse))
 def test_leader_and_isr_response_java(
     instance: LeaderAndIsrResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v1_request.py
+++ b/tests/generated/test_leader_and_isr_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_state: Final = entity_reader(LeaderAndIsrPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionState))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_state_roundtrip(
@@ -33,6 +35,7 @@ def test_leader_and_isr_partition_state_roundtrip(
 read_leader_and_isr_live_leader: Final = entity_reader(LeaderAndIsrLiveLeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrLiveLeader))
 @settings(max_examples=1)
 def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) -> None:
@@ -47,6 +50,7 @@ def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) 
 read_leader_and_isr_request: Final = entity_reader(LeaderAndIsrRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrRequest))
 @settings(max_examples=1)
 def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None:
@@ -58,6 +62,7 @@ def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrRequest))
 def test_leader_and_isr_request_java(
     instance: LeaderAndIsrRequest, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v1_response.py
+++ b/tests/generated/test_leader_and_isr_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_error: Final = entity_reader(LeaderAndIsrPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionError))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_leader_and_isr_partition_error_roundtrip(
 read_leader_and_isr_response: Final = entity_reader(LeaderAndIsrResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrResponse))
 @settings(max_examples=1)
 def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> None:
@@ -43,6 +46,7 @@ def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> No
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrResponse))
 def test_leader_and_isr_response_java(
     instance: LeaderAndIsrResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v2_request.py
+++ b/tests/generated/test_leader_and_isr_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_state: Final = entity_reader(LeaderAndIsrPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionState))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_state_roundtrip(
@@ -34,6 +36,7 @@ def test_leader_and_isr_partition_state_roundtrip(
 read_leader_and_isr_topic_state: Final = entity_reader(LeaderAndIsrTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicState))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) -> None:
@@ -48,6 +51,7 @@ def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) 
 read_leader_and_isr_live_leader: Final = entity_reader(LeaderAndIsrLiveLeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrLiveLeader))
 @settings(max_examples=1)
 def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) -> None:
@@ -62,6 +66,7 @@ def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) 
 read_leader_and_isr_request: Final = entity_reader(LeaderAndIsrRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrRequest))
 @settings(max_examples=1)
 def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None:
@@ -73,6 +78,7 @@ def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrRequest))
 def test_leader_and_isr_request_java(
     instance: LeaderAndIsrRequest, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v2_response.py
+++ b/tests/generated/test_leader_and_isr_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_error: Final = entity_reader(LeaderAndIsrPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionError))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_leader_and_isr_partition_error_roundtrip(
 read_leader_and_isr_response: Final = entity_reader(LeaderAndIsrResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrResponse))
 @settings(max_examples=1)
 def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> None:
@@ -43,6 +46,7 @@ def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> No
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrResponse))
 def test_leader_and_isr_response_java(
     instance: LeaderAndIsrResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v3_request.py
+++ b/tests/generated/test_leader_and_isr_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_state: Final = entity_reader(LeaderAndIsrPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionState))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_state_roundtrip(
@@ -34,6 +36,7 @@ def test_leader_and_isr_partition_state_roundtrip(
 read_leader_and_isr_topic_state: Final = entity_reader(LeaderAndIsrTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicState))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) -> None:
@@ -48,6 +51,7 @@ def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) 
 read_leader_and_isr_live_leader: Final = entity_reader(LeaderAndIsrLiveLeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrLiveLeader))
 @settings(max_examples=1)
 def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) -> None:
@@ -62,6 +66,7 @@ def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) 
 read_leader_and_isr_request: Final = entity_reader(LeaderAndIsrRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrRequest))
 @settings(max_examples=1)
 def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None:
@@ -73,6 +78,7 @@ def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrRequest))
 def test_leader_and_isr_request_java(
     instance: LeaderAndIsrRequest, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v3_response.py
+++ b/tests/generated/test_leader_and_isr_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_error: Final = entity_reader(LeaderAndIsrPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionError))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_leader_and_isr_partition_error_roundtrip(
 read_leader_and_isr_response: Final = entity_reader(LeaderAndIsrResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrResponse))
 @settings(max_examples=1)
 def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> None:
@@ -43,6 +46,7 @@ def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> No
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrResponse))
 def test_leader_and_isr_response_java(
     instance: LeaderAndIsrResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v4_request.py
+++ b/tests/generated/test_leader_and_isr_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_state: Final = entity_reader(LeaderAndIsrPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionState))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_state_roundtrip(
@@ -34,6 +36,7 @@ def test_leader_and_isr_partition_state_roundtrip(
 read_leader_and_isr_topic_state: Final = entity_reader(LeaderAndIsrTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicState))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) -> None:
@@ -48,6 +51,7 @@ def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) 
 read_leader_and_isr_live_leader: Final = entity_reader(LeaderAndIsrLiveLeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrLiveLeader))
 @settings(max_examples=1)
 def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) -> None:
@@ -62,6 +66,7 @@ def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) 
 read_leader_and_isr_request: Final = entity_reader(LeaderAndIsrRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrRequest))
 @settings(max_examples=1)
 def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None:
@@ -73,6 +78,7 @@ def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrRequest))
 def test_leader_and_isr_request_java(
     instance: LeaderAndIsrRequest, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v4_response.py
+++ b/tests/generated/test_leader_and_isr_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_error: Final = entity_reader(LeaderAndIsrPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionError))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_leader_and_isr_partition_error_roundtrip(
 read_leader_and_isr_response: Final = entity_reader(LeaderAndIsrResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrResponse))
 @settings(max_examples=1)
 def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> None:
@@ -43,6 +46,7 @@ def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> No
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrResponse))
 def test_leader_and_isr_response_java(
     instance: LeaderAndIsrResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v5_request.py
+++ b/tests/generated/test_leader_and_isr_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_state: Final = entity_reader(LeaderAndIsrPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionState))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_state_roundtrip(
@@ -34,6 +36,7 @@ def test_leader_and_isr_partition_state_roundtrip(
 read_leader_and_isr_topic_state: Final = entity_reader(LeaderAndIsrTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicState))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) -> None:
@@ -48,6 +51,7 @@ def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) 
 read_leader_and_isr_live_leader: Final = entity_reader(LeaderAndIsrLiveLeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrLiveLeader))
 @settings(max_examples=1)
 def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) -> None:
@@ -62,6 +66,7 @@ def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) 
 read_leader_and_isr_request: Final = entity_reader(LeaderAndIsrRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrRequest))
 @settings(max_examples=1)
 def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None:
@@ -73,6 +78,7 @@ def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrRequest))
 def test_leader_and_isr_request_java(
     instance: LeaderAndIsrRequest, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v5_response.py
+++ b/tests/generated/test_leader_and_isr_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_error: Final = entity_reader(LeaderAndIsrPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionError))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_error_roundtrip(
@@ -33,6 +35,7 @@ def test_leader_and_isr_partition_error_roundtrip(
 read_leader_and_isr_topic_error: Final = entity_reader(LeaderAndIsrTopicError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicError))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_error_roundtrip(instance: LeaderAndIsrTopicError) -> None:
@@ -47,6 +50,7 @@ def test_leader_and_isr_topic_error_roundtrip(instance: LeaderAndIsrTopicError) 
 read_leader_and_isr_response: Final = entity_reader(LeaderAndIsrResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrResponse))
 @settings(max_examples=1)
 def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> None:
@@ -58,6 +62,7 @@ def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> No
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrResponse))
 def test_leader_and_isr_response_java(
     instance: LeaderAndIsrResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v6_request.py
+++ b/tests/generated/test_leader_and_isr_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_state: Final = entity_reader(LeaderAndIsrPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionState))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_state_roundtrip(
@@ -34,6 +36,7 @@ def test_leader_and_isr_partition_state_roundtrip(
 read_leader_and_isr_topic_state: Final = entity_reader(LeaderAndIsrTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicState))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) -> None:
@@ -48,6 +51,7 @@ def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) 
 read_leader_and_isr_live_leader: Final = entity_reader(LeaderAndIsrLiveLeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrLiveLeader))
 @settings(max_examples=1)
 def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) -> None:
@@ -62,6 +66,7 @@ def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) 
 read_leader_and_isr_request: Final = entity_reader(LeaderAndIsrRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrRequest))
 @settings(max_examples=1)
 def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None:
@@ -73,6 +78,7 @@ def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrRequest))
 def test_leader_and_isr_request_java(
     instance: LeaderAndIsrRequest, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v6_response.py
+++ b/tests/generated/test_leader_and_isr_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_error: Final = entity_reader(LeaderAndIsrPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionError))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_error_roundtrip(
@@ -33,6 +35,7 @@ def test_leader_and_isr_partition_error_roundtrip(
 read_leader_and_isr_topic_error: Final = entity_reader(LeaderAndIsrTopicError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicError))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_error_roundtrip(instance: LeaderAndIsrTopicError) -> None:
@@ -47,6 +50,7 @@ def test_leader_and_isr_topic_error_roundtrip(instance: LeaderAndIsrTopicError) 
 read_leader_and_isr_response: Final = entity_reader(LeaderAndIsrResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrResponse))
 @settings(max_examples=1)
 def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> None:
@@ -58,6 +62,7 @@ def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> No
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrResponse))
 def test_leader_and_isr_response_java(
     instance: LeaderAndIsrResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v7_request.py
+++ b/tests/generated/test_leader_and_isr_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_state: Final = entity_reader(LeaderAndIsrPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionState))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_state_roundtrip(
@@ -34,6 +36,7 @@ def test_leader_and_isr_partition_state_roundtrip(
 read_leader_and_isr_topic_state: Final = entity_reader(LeaderAndIsrTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicState))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) -> None:
@@ -48,6 +51,7 @@ def test_leader_and_isr_topic_state_roundtrip(instance: LeaderAndIsrTopicState) 
 read_leader_and_isr_live_leader: Final = entity_reader(LeaderAndIsrLiveLeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrLiveLeader))
 @settings(max_examples=1)
 def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) -> None:
@@ -62,6 +66,7 @@ def test_leader_and_isr_live_leader_roundtrip(instance: LeaderAndIsrLiveLeader) 
 read_leader_and_isr_request: Final = entity_reader(LeaderAndIsrRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrRequest))
 @settings(max_examples=1)
 def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None:
@@ -73,6 +78,7 @@ def test_leader_and_isr_request_roundtrip(instance: LeaderAndIsrRequest) -> None
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrRequest))
 def test_leader_and_isr_request_java(
     instance: LeaderAndIsrRequest, java_tester: JavaTester

--- a/tests/generated/test_leader_and_isr_v7_response.py
+++ b/tests/generated/test_leader_and_isr_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_leader_and_isr_partition_error: Final = entity_reader(LeaderAndIsrPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrPartitionError))
 @settings(max_examples=1)
 def test_leader_and_isr_partition_error_roundtrip(
@@ -33,6 +35,7 @@ def test_leader_and_isr_partition_error_roundtrip(
 read_leader_and_isr_topic_error: Final = entity_reader(LeaderAndIsrTopicError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrTopicError))
 @settings(max_examples=1)
 def test_leader_and_isr_topic_error_roundtrip(instance: LeaderAndIsrTopicError) -> None:
@@ -47,6 +50,7 @@ def test_leader_and_isr_topic_error_roundtrip(instance: LeaderAndIsrTopicError) 
 read_leader_and_isr_response: Final = entity_reader(LeaderAndIsrResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderAndIsrResponse))
 @settings(max_examples=1)
 def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> None:
@@ -58,6 +62,7 @@ def test_leader_and_isr_response_roundtrip(instance: LeaderAndIsrResponse) -> No
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderAndIsrResponse))
 def test_leader_and_isr_response_java(
     instance: LeaderAndIsrResponse, java_tester: JavaTester

--- a/tests/generated/test_leader_change_message_v0_data.py
+++ b/tests/generated/test_leader_change_message_v0_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_voter: Final = entity_reader(Voter)
 
 
+@pytest.mark.roundtrip
 @given(from_type(Voter))
 @settings(max_examples=1)
 def test_voter_roundtrip(instance: Voter) -> None:
@@ -30,6 +32,7 @@ def test_voter_roundtrip(instance: Voter) -> None:
 read_leader_change_message: Final = entity_reader(LeaderChangeMessage)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaderChangeMessage))
 @settings(max_examples=1)
 def test_leader_change_message_roundtrip(instance: LeaderChangeMessage) -> None:
@@ -41,6 +44,7 @@ def test_leader_change_message_roundtrip(instance: LeaderChangeMessage) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaderChangeMessage))
 def test_leader_change_message_java(
     instance: LeaderChangeMessage, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v0_request.py
+++ b/tests/generated/test_leave_group_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_leave_group_request: Final = entity_reader(LeaveGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupRequest))
 @settings(max_examples=1)
 def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
@@ -26,6 +28,7 @@ def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupRequest))
 def test_leave_group_request_java(
     instance: LeaveGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v0_response.py
+++ b/tests/generated/test_leave_group_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_leave_group_response: Final = entity_reader(LeaveGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupResponse))
 @settings(max_examples=1)
 def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupResponse))
 def test_leave_group_response_java(
     instance: LeaveGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v1_request.py
+++ b/tests/generated/test_leave_group_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_leave_group_request: Final = entity_reader(LeaveGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupRequest))
 @settings(max_examples=1)
 def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
@@ -26,6 +28,7 @@ def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupRequest))
 def test_leave_group_request_java(
     instance: LeaveGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v1_response.py
+++ b/tests/generated/test_leave_group_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_leave_group_response: Final = entity_reader(LeaveGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupResponse))
 @settings(max_examples=1)
 def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupResponse))
 def test_leave_group_response_java(
     instance: LeaveGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v2_request.py
+++ b/tests/generated/test_leave_group_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_leave_group_request: Final = entity_reader(LeaveGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupRequest))
 @settings(max_examples=1)
 def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
@@ -26,6 +28,7 @@ def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupRequest))
 def test_leave_group_request_java(
     instance: LeaveGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v2_response.py
+++ b/tests/generated/test_leave_group_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_leave_group_response: Final = entity_reader(LeaveGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupResponse))
 @settings(max_examples=1)
 def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupResponse))
 def test_leave_group_response_java(
     instance: LeaveGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v3_request.py
+++ b/tests/generated/test_leave_group_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_member_identity: Final = entity_reader(MemberIdentity)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MemberIdentity))
 @settings(max_examples=1)
 def test_member_identity_roundtrip(instance: MemberIdentity) -> None:
@@ -30,6 +32,7 @@ def test_member_identity_roundtrip(instance: MemberIdentity) -> None:
 read_leave_group_request: Final = entity_reader(LeaveGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupRequest))
 @settings(max_examples=1)
 def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
@@ -41,6 +44,7 @@ def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupRequest))
 def test_leave_group_request_java(
     instance: LeaveGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v3_response.py
+++ b/tests/generated/test_leave_group_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_member_response: Final = entity_reader(MemberResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MemberResponse))
 @settings(max_examples=1)
 def test_member_response_roundtrip(instance: MemberResponse) -> None:
@@ -30,6 +32,7 @@ def test_member_response_roundtrip(instance: MemberResponse) -> None:
 read_leave_group_response: Final = entity_reader(LeaveGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupResponse))
 @settings(max_examples=1)
 def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
@@ -41,6 +44,7 @@ def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupResponse))
 def test_leave_group_response_java(
     instance: LeaveGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v4_request.py
+++ b/tests/generated/test_leave_group_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_member_identity: Final = entity_reader(MemberIdentity)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MemberIdentity))
 @settings(max_examples=1)
 def test_member_identity_roundtrip(instance: MemberIdentity) -> None:
@@ -30,6 +32,7 @@ def test_member_identity_roundtrip(instance: MemberIdentity) -> None:
 read_leave_group_request: Final = entity_reader(LeaveGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupRequest))
 @settings(max_examples=1)
 def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
@@ -41,6 +44,7 @@ def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupRequest))
 def test_leave_group_request_java(
     instance: LeaveGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v4_response.py
+++ b/tests/generated/test_leave_group_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_member_response: Final = entity_reader(MemberResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MemberResponse))
 @settings(max_examples=1)
 def test_member_response_roundtrip(instance: MemberResponse) -> None:
@@ -30,6 +32,7 @@ def test_member_response_roundtrip(instance: MemberResponse) -> None:
 read_leave_group_response: Final = entity_reader(LeaveGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupResponse))
 @settings(max_examples=1)
 def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
@@ -41,6 +44,7 @@ def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupResponse))
 def test_leave_group_response_java(
     instance: LeaveGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v5_request.py
+++ b/tests/generated/test_leave_group_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_member_identity: Final = entity_reader(MemberIdentity)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MemberIdentity))
 @settings(max_examples=1)
 def test_member_identity_roundtrip(instance: MemberIdentity) -> None:
@@ -30,6 +32,7 @@ def test_member_identity_roundtrip(instance: MemberIdentity) -> None:
 read_leave_group_request: Final = entity_reader(LeaveGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupRequest))
 @settings(max_examples=1)
 def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
@@ -41,6 +44,7 @@ def test_leave_group_request_roundtrip(instance: LeaveGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupRequest))
 def test_leave_group_request_java(
     instance: LeaveGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_leave_group_v5_response.py
+++ b/tests/generated/test_leave_group_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_member_response: Final = entity_reader(MemberResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MemberResponse))
 @settings(max_examples=1)
 def test_member_response_roundtrip(instance: MemberResponse) -> None:
@@ -30,6 +32,7 @@ def test_member_response_roundtrip(instance: MemberResponse) -> None:
 read_leave_group_response: Final = entity_reader(LeaveGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(LeaveGroupResponse))
 @settings(max_examples=1)
 def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
@@ -41,6 +44,7 @@ def test_leave_group_response_roundtrip(instance: LeaveGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(LeaveGroupResponse))
 def test_leave_group_response_java(
     instance: LeaveGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v0_request.py
+++ b/tests/generated/test_list_groups_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_list_groups_request: Final = entity_reader(ListGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsRequest))
 @settings(max_examples=1)
 def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsRequest))
 def test_list_groups_request_java(
     instance: ListGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v0_response.py
+++ b/tests/generated/test_list_groups_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_listed_group: Final = entity_reader(ListedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListedGroup))
 @settings(max_examples=1)
 def test_listed_group_roundtrip(instance: ListedGroup) -> None:
@@ -30,6 +32,7 @@ def test_listed_group_roundtrip(instance: ListedGroup) -> None:
 read_list_groups_response: Final = entity_reader(ListGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsResponse))
 @settings(max_examples=1)
 def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
@@ -41,6 +44,7 @@ def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsResponse))
 def test_list_groups_response_java(
     instance: ListGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v1_request.py
+++ b/tests/generated/test_list_groups_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_list_groups_request: Final = entity_reader(ListGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsRequest))
 @settings(max_examples=1)
 def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsRequest))
 def test_list_groups_request_java(
     instance: ListGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v1_response.py
+++ b/tests/generated/test_list_groups_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_listed_group: Final = entity_reader(ListedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListedGroup))
 @settings(max_examples=1)
 def test_listed_group_roundtrip(instance: ListedGroup) -> None:
@@ -30,6 +32,7 @@ def test_listed_group_roundtrip(instance: ListedGroup) -> None:
 read_list_groups_response: Final = entity_reader(ListGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsResponse))
 @settings(max_examples=1)
 def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
@@ -41,6 +44,7 @@ def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsResponse))
 def test_list_groups_response_java(
     instance: ListGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v2_request.py
+++ b/tests/generated/test_list_groups_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_list_groups_request: Final = entity_reader(ListGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsRequest))
 @settings(max_examples=1)
 def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsRequest))
 def test_list_groups_request_java(
     instance: ListGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v2_response.py
+++ b/tests/generated/test_list_groups_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_listed_group: Final = entity_reader(ListedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListedGroup))
 @settings(max_examples=1)
 def test_listed_group_roundtrip(instance: ListedGroup) -> None:
@@ -30,6 +32,7 @@ def test_listed_group_roundtrip(instance: ListedGroup) -> None:
 read_list_groups_response: Final = entity_reader(ListGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsResponse))
 @settings(max_examples=1)
 def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
@@ -41,6 +44,7 @@ def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsResponse))
 def test_list_groups_response_java(
     instance: ListGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v3_request.py
+++ b/tests/generated/test_list_groups_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_list_groups_request: Final = entity_reader(ListGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsRequest))
 @settings(max_examples=1)
 def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsRequest))
 def test_list_groups_request_java(
     instance: ListGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v3_response.py
+++ b/tests/generated/test_list_groups_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_listed_group: Final = entity_reader(ListedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListedGroup))
 @settings(max_examples=1)
 def test_listed_group_roundtrip(instance: ListedGroup) -> None:
@@ -30,6 +32,7 @@ def test_listed_group_roundtrip(instance: ListedGroup) -> None:
 read_list_groups_response: Final = entity_reader(ListGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsResponse))
 @settings(max_examples=1)
 def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
@@ -41,6 +44,7 @@ def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsResponse))
 def test_list_groups_response_java(
     instance: ListGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v4_request.py
+++ b/tests/generated/test_list_groups_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_list_groups_request: Final = entity_reader(ListGroupsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsRequest))
 @settings(max_examples=1)
 def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
@@ -26,6 +28,7 @@ def test_list_groups_request_roundtrip(instance: ListGroupsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsRequest))
 def test_list_groups_request_java(
     instance: ListGroupsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_groups_v4_response.py
+++ b/tests/generated/test_list_groups_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_listed_group: Final = entity_reader(ListedGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListedGroup))
 @settings(max_examples=1)
 def test_listed_group_roundtrip(instance: ListedGroup) -> None:
@@ -30,6 +32,7 @@ def test_listed_group_roundtrip(instance: ListedGroup) -> None:
 read_list_groups_response: Final = entity_reader(ListGroupsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListGroupsResponse))
 @settings(max_examples=1)
 def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
@@ -41,6 +44,7 @@ def test_list_groups_response_roundtrip(instance: ListGroupsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListGroupsResponse))
 def test_list_groups_response_java(
     instance: ListGroupsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v0_request.py
+++ b/tests/generated/test_list_offsets_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v0_response.py
+++ b/tests/generated/test_list_offsets_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v1_request.py
+++ b/tests/generated/test_list_offsets_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v1_response.py
+++ b/tests/generated/test_list_offsets_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v2_request.py
+++ b/tests/generated/test_list_offsets_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v2_response.py
+++ b/tests/generated/test_list_offsets_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v3_request.py
+++ b/tests/generated/test_list_offsets_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v3_response.py
+++ b/tests/generated/test_list_offsets_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v4_request.py
+++ b/tests/generated/test_list_offsets_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v4_response.py
+++ b/tests/generated/test_list_offsets_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v5_request.py
+++ b/tests/generated/test_list_offsets_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v5_response.py
+++ b/tests/generated/test_list_offsets_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v6_request.py
+++ b/tests/generated/test_list_offsets_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v6_response.py
+++ b/tests/generated/test_list_offsets_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v7_request.py
+++ b/tests/generated/test_list_offsets_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v7_response.py
+++ b/tests/generated/test_list_offsets_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v8_request.py
+++ b/tests/generated/test_list_offsets_v8_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_list_offsets_partition: Final = entity_reader(ListOffsetsPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartition))
 @settings(max_examples=1)
 def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> None:
@@ -31,6 +33,7 @@ def test_list_offsets_partition_roundtrip(instance: ListOffsetsPartition) -> Non
 read_list_offsets_topic: Final = entity_reader(ListOffsetsTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopic))
 @settings(max_examples=1)
 def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
@@ -45,6 +48,7 @@ def test_list_offsets_topic_roundtrip(instance: ListOffsetsTopic) -> None:
 read_list_offsets_request: Final = entity_reader(ListOffsetsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsRequest))
 @settings(max_examples=1)
 def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
@@ -56,6 +60,7 @@ def test_list_offsets_request_roundtrip(instance: ListOffsetsRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsRequest))
 def test_list_offsets_request_java(
     instance: ListOffsetsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_offsets_v8_response.py
+++ b/tests/generated/test_list_offsets_v8_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_list_offsets_partition_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsPartitionResponse))
 @settings(max_examples=1)
 def test_list_offsets_partition_response_roundtrip(
@@ -35,6 +37,7 @@ def test_list_offsets_partition_response_roundtrip(
 read_list_offsets_topic_response: Final = entity_reader(ListOffsetsTopicResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsTopicResponse))
 @settings(max_examples=1)
 def test_list_offsets_topic_response_roundtrip(
@@ -51,6 +54,7 @@ def test_list_offsets_topic_response_roundtrip(
 read_list_offsets_response: Final = entity_reader(ListOffsetsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListOffsetsResponse))
 @settings(max_examples=1)
 def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
@@ -62,6 +66,7 @@ def test_list_offsets_response_roundtrip(instance: ListOffsetsResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListOffsetsResponse))
 def test_list_offsets_response_java(
     instance: ListOffsetsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_partition_reassignments_v0_request.py
+++ b/tests/generated/test_list_partition_reassignments_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -22,6 +23,7 @@ read_list_partition_reassignments_topics: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListPartitionReassignmentsTopics))
 @settings(max_examples=1)
 def test_list_partition_reassignments_topics_roundtrip(
@@ -40,6 +42,7 @@ read_list_partition_reassignments_request: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListPartitionReassignmentsRequest))
 @settings(max_examples=1)
 def test_list_partition_reassignments_request_roundtrip(
@@ -53,6 +56,7 @@ def test_list_partition_reassignments_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListPartitionReassignmentsRequest))
 def test_list_partition_reassignments_request_java(
     instance: ListPartitionReassignmentsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_partition_reassignments_v0_response.py
+++ b/tests/generated/test_list_partition_reassignments_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ from tests.conftest import setup_buffer
 read_ongoing_partition_reassignment: Final = entity_reader(OngoingPartitionReassignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OngoingPartitionReassignment))
 @settings(max_examples=1)
 def test_ongoing_partition_reassignment_roundtrip(
@@ -37,6 +39,7 @@ def test_ongoing_partition_reassignment_roundtrip(
 read_ongoing_topic_reassignment: Final = entity_reader(OngoingTopicReassignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OngoingTopicReassignment))
 @settings(max_examples=1)
 def test_ongoing_topic_reassignment_roundtrip(
@@ -55,6 +58,7 @@ read_list_partition_reassignments_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListPartitionReassignmentsResponse))
 @settings(max_examples=1)
 def test_list_partition_reassignments_response_roundtrip(
@@ -68,6 +72,7 @@ def test_list_partition_reassignments_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListPartitionReassignmentsResponse))
 def test_list_partition_reassignments_response_java(
     instance: ListPartitionReassignmentsResponse, java_tester: JavaTester

--- a/tests/generated/test_list_transactions_v0_request.py
+++ b/tests/generated/test_list_transactions_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_list_transactions_request: Final = entity_reader(ListTransactionsRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListTransactionsRequest))
 @settings(max_examples=1)
 def test_list_transactions_request_roundtrip(instance: ListTransactionsRequest) -> None:
@@ -26,6 +28,7 @@ def test_list_transactions_request_roundtrip(instance: ListTransactionsRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListTransactionsRequest))
 def test_list_transactions_request_java(
     instance: ListTransactionsRequest, java_tester: JavaTester

--- a/tests/generated/test_list_transactions_v0_response.py
+++ b/tests/generated/test_list_transactions_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_transaction_state: Final = entity_reader(TransactionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TransactionState))
 @settings(max_examples=1)
 def test_transaction_state_roundtrip(instance: TransactionState) -> None:
@@ -30,6 +32,7 @@ def test_transaction_state_roundtrip(instance: TransactionState) -> None:
 read_list_transactions_response: Final = entity_reader(ListTransactionsResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ListTransactionsResponse))
 @settings(max_examples=1)
 def test_list_transactions_response_roundtrip(
@@ -43,6 +46,7 @@ def test_list_transactions_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ListTransactionsResponse))
 def test_list_transactions_response_java(
     instance: ListTransactionsResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v0_request.py
+++ b/tests/generated/test_metadata_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v0_response.py
+++ b/tests/generated/test_metadata_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v10_request.py
+++ b/tests/generated/test_metadata_v10_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v10_response.py
+++ b/tests/generated/test_metadata_v10_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v11_request.py
+++ b/tests/generated/test_metadata_v11_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v11_response.py
+++ b/tests/generated/test_metadata_v11_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v12_request.py
+++ b/tests/generated/test_metadata_v12_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v12_response.py
+++ b/tests/generated/test_metadata_v12_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v1_request.py
+++ b/tests/generated/test_metadata_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v1_response.py
+++ b/tests/generated/test_metadata_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v2_request.py
+++ b/tests/generated/test_metadata_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v2_response.py
+++ b/tests/generated/test_metadata_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v3_request.py
+++ b/tests/generated/test_metadata_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v3_response.py
+++ b/tests/generated/test_metadata_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v4_request.py
+++ b/tests/generated/test_metadata_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v4_response.py
+++ b/tests/generated/test_metadata_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v5_request.py
+++ b/tests/generated/test_metadata_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v5_response.py
+++ b/tests/generated/test_metadata_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v6_request.py
+++ b/tests/generated/test_metadata_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v6_response.py
+++ b/tests/generated/test_metadata_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v7_request.py
+++ b/tests/generated/test_metadata_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v7_response.py
+++ b/tests/generated/test_metadata_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v8_request.py
+++ b/tests/generated/test_metadata_v8_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v8_response.py
+++ b/tests/generated/test_metadata_v8_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_metadata_v9_request.py
+++ b/tests/generated/test_metadata_v9_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_metadata_request_topic: Final = entity_reader(MetadataRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequestTopic))
 @settings(max_examples=1)
 def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> None:
@@ -30,6 +32,7 @@ def test_metadata_request_topic_roundtrip(instance: MetadataRequestTopic) -> Non
 read_metadata_request: Final = entity_reader(MetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataRequest))
 @settings(max_examples=1)
 def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
@@ -41,6 +44,7 @@ def test_metadata_request_roundtrip(instance: MetadataRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataRequest))
 def test_metadata_request_java(
     instance: MetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_metadata_v9_response.py
+++ b/tests/generated/test_metadata_v9_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_metadata_response_broker: Final = entity_reader(MetadataResponseBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseBroker))
 @settings(max_examples=1)
 def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) -> None:
@@ -32,6 +34,7 @@ def test_metadata_response_broker_roundtrip(instance: MetadataResponseBroker) ->
 read_metadata_response_partition: Final = entity_reader(MetadataResponsePartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponsePartition))
 @settings(max_examples=1)
 def test_metadata_response_partition_roundtrip(
@@ -48,6 +51,7 @@ def test_metadata_response_partition_roundtrip(
 read_metadata_response_topic: Final = entity_reader(MetadataResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponseTopic))
 @settings(max_examples=1)
 def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> None:
@@ -62,6 +66,7 @@ def test_metadata_response_topic_roundtrip(instance: MetadataResponseTopic) -> N
 read_metadata_response: Final = entity_reader(MetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(MetadataResponse))
 @settings(max_examples=1)
 def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
@@ -73,6 +78,7 @@ def test_metadata_response_roundtrip(instance: MetadataResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(MetadataResponse))
 def test_metadata_response_java(
     instance: MetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v0_request.py
+++ b/tests/generated/test_offset_commit_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v0_response.py
+++ b/tests/generated/test_offset_commit_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v1_request.py
+++ b/tests/generated/test_offset_commit_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v1_response.py
+++ b/tests/generated/test_offset_commit_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v2_request.py
+++ b/tests/generated/test_offset_commit_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v2_response.py
+++ b/tests/generated/test_offset_commit_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v3_request.py
+++ b/tests/generated/test_offset_commit_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v3_response.py
+++ b/tests/generated/test_offset_commit_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v4_request.py
+++ b/tests/generated/test_offset_commit_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v4_response.py
+++ b/tests/generated/test_offset_commit_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v5_request.py
+++ b/tests/generated/test_offset_commit_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v5_response.py
+++ b/tests/generated/test_offset_commit_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v6_request.py
+++ b/tests/generated/test_offset_commit_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v6_response.py
+++ b/tests/generated/test_offset_commit_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v7_request.py
+++ b/tests/generated/test_offset_commit_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v7_response.py
+++ b/tests/generated/test_offset_commit_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v8_request.py
+++ b/tests/generated/test_offset_commit_v8_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v8_response.py
+++ b/tests/generated/test_offset_commit_v8_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v9_request.py
+++ b/tests/generated/test_offset_commit_v9_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_request_partition_roundtrip(
 read_offset_commit_request_topic: Final = entity_reader(OffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_request_topic_roundtrip(
 read_offset_commit_request: Final = entity_reader(OffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitRequest))
 @settings(max_examples=1)
 def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_request_roundtrip(instance: OffsetCommitRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitRequest))
 def test_offset_commit_request_java(
     instance: OffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_commit_v9_response.py
+++ b/tests/generated/test_offset_commit_v9_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_offset_commit_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_commit_response_partition_roundtrip(
 read_offset_commit_response_topic: Final = entity_reader(OffsetCommitResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_offset_commit_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_commit_response_topic_roundtrip(
 read_offset_commit_response: Final = entity_reader(OffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetCommitResponse))
 @settings(max_examples=1)
 def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_commit_response_roundtrip(instance: OffsetCommitResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetCommitResponse))
 def test_offset_commit_response_java(
     instance: OffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_delete_v0_request.py
+++ b/tests/generated/test_offset_delete_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_delete_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetDeleteRequestPartition))
 @settings(max_examples=1)
 def test_offset_delete_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_delete_request_partition_roundtrip(
 read_offset_delete_request_topic: Final = entity_reader(OffsetDeleteRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetDeleteRequestTopic))
 @settings(max_examples=1)
 def test_offset_delete_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_delete_request_topic_roundtrip(
 read_offset_delete_request: Final = entity_reader(OffsetDeleteRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetDeleteRequest))
 @settings(max_examples=1)
 def test_offset_delete_request_roundtrip(instance: OffsetDeleteRequest) -> None:
@@ -62,6 +66,7 @@ def test_offset_delete_request_roundtrip(instance: OffsetDeleteRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetDeleteRequest))
 def test_offset_delete_request_java(
     instance: OffsetDeleteRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_delete_v0_response.py
+++ b/tests/generated/test_offset_delete_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_delete_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetDeleteResponsePartition))
 @settings(max_examples=1)
 def test_offset_delete_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_delete_response_partition_roundtrip(
 read_offset_delete_response_topic: Final = entity_reader(OffsetDeleteResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetDeleteResponseTopic))
 @settings(max_examples=1)
 def test_offset_delete_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_delete_response_topic_roundtrip(
 read_offset_delete_response: Final = entity_reader(OffsetDeleteResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetDeleteResponse))
 @settings(max_examples=1)
 def test_offset_delete_response_roundtrip(instance: OffsetDeleteResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_delete_response_roundtrip(instance: OffsetDeleteResponse) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetDeleteResponse))
 def test_offset_delete_response_java(
     instance: OffsetDeleteResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v0_request.py
+++ b/tests/generated/test_offset_fetch_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topic: Final = entity_reader(OffsetFetchRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopic))
 @settings(max_examples=1)
 def test_offset_fetch_request_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_offset_fetch_request_topic_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -43,6 +46,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v0_response.py
+++ b/tests/generated/test_offset_fetch_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_fetch_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartition))
 @settings(max_examples=1)
 def test_offset_fetch_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_fetch_response_partition_roundtrip(
 read_offset_fetch_response_topic: Final = entity_reader(OffsetFetchResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopic))
 @settings(max_examples=1)
 def test_offset_fetch_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_fetch_response_topic_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v1_request.py
+++ b/tests/generated/test_offset_fetch_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topic: Final = entity_reader(OffsetFetchRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopic))
 @settings(max_examples=1)
 def test_offset_fetch_request_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_offset_fetch_request_topic_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -43,6 +46,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v1_response.py
+++ b/tests/generated/test_offset_fetch_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_fetch_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartition))
 @settings(max_examples=1)
 def test_offset_fetch_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_fetch_response_partition_roundtrip(
 read_offset_fetch_response_topic: Final = entity_reader(OffsetFetchResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopic))
 @settings(max_examples=1)
 def test_offset_fetch_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_fetch_response_topic_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v2_request.py
+++ b/tests/generated/test_offset_fetch_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topic: Final = entity_reader(OffsetFetchRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopic))
 @settings(max_examples=1)
 def test_offset_fetch_request_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_offset_fetch_request_topic_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -43,6 +46,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v2_response.py
+++ b/tests/generated/test_offset_fetch_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_fetch_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartition))
 @settings(max_examples=1)
 def test_offset_fetch_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_fetch_response_partition_roundtrip(
 read_offset_fetch_response_topic: Final = entity_reader(OffsetFetchResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopic))
 @settings(max_examples=1)
 def test_offset_fetch_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_fetch_response_topic_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v3_request.py
+++ b/tests/generated/test_offset_fetch_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topic: Final = entity_reader(OffsetFetchRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopic))
 @settings(max_examples=1)
 def test_offset_fetch_request_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_offset_fetch_request_topic_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -43,6 +46,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v3_response.py
+++ b/tests/generated/test_offset_fetch_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_fetch_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartition))
 @settings(max_examples=1)
 def test_offset_fetch_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_fetch_response_partition_roundtrip(
 read_offset_fetch_response_topic: Final = entity_reader(OffsetFetchResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopic))
 @settings(max_examples=1)
 def test_offset_fetch_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_fetch_response_topic_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v4_request.py
+++ b/tests/generated/test_offset_fetch_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topic: Final = entity_reader(OffsetFetchRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopic))
 @settings(max_examples=1)
 def test_offset_fetch_request_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_offset_fetch_request_topic_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -43,6 +46,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v4_response.py
+++ b/tests/generated/test_offset_fetch_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_fetch_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartition))
 @settings(max_examples=1)
 def test_offset_fetch_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_fetch_response_partition_roundtrip(
 read_offset_fetch_response_topic: Final = entity_reader(OffsetFetchResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopic))
 @settings(max_examples=1)
 def test_offset_fetch_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_fetch_response_topic_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v5_request.py
+++ b/tests/generated/test_offset_fetch_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topic: Final = entity_reader(OffsetFetchRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopic))
 @settings(max_examples=1)
 def test_offset_fetch_request_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_offset_fetch_request_topic_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -43,6 +46,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v5_response.py
+++ b/tests/generated/test_offset_fetch_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_fetch_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartition))
 @settings(max_examples=1)
 def test_offset_fetch_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_fetch_response_partition_roundtrip(
 read_offset_fetch_response_topic: Final = entity_reader(OffsetFetchResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopic))
 @settings(max_examples=1)
 def test_offset_fetch_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_fetch_response_topic_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v6_request.py
+++ b/tests/generated/test_offset_fetch_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topic: Final = entity_reader(OffsetFetchRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopic))
 @settings(max_examples=1)
 def test_offset_fetch_request_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_offset_fetch_request_topic_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -43,6 +46,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v6_response.py
+++ b/tests/generated/test_offset_fetch_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_fetch_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartition))
 @settings(max_examples=1)
 def test_offset_fetch_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_fetch_response_partition_roundtrip(
 read_offset_fetch_response_topic: Final = entity_reader(OffsetFetchResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopic))
 @settings(max_examples=1)
 def test_offset_fetch_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_fetch_response_topic_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v7_request.py
+++ b/tests/generated/test_offset_fetch_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topic: Final = entity_reader(OffsetFetchRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopic))
 @settings(max_examples=1)
 def test_offset_fetch_request_topic_roundtrip(
@@ -32,6 +34,7 @@ def test_offset_fetch_request_topic_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -43,6 +46,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v7_response.py
+++ b/tests/generated/test_offset_fetch_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_offset_fetch_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartition))
 @settings(max_examples=1)
 def test_offset_fetch_response_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_offset_fetch_response_partition_roundtrip(
 read_offset_fetch_response_topic: Final = entity_reader(OffsetFetchResponseTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopic))
 @settings(max_examples=1)
 def test_offset_fetch_response_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_offset_fetch_response_topic_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -62,6 +66,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v8_request.py
+++ b/tests/generated/test_offset_fetch_v8_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_offset_fetch_request_topics: Final = entity_reader(OffsetFetchRequestTopics)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestTopics))
 @settings(max_examples=1)
 def test_offset_fetch_request_topics_roundtrip(
@@ -33,6 +35,7 @@ def test_offset_fetch_request_topics_roundtrip(
 read_offset_fetch_request_group: Final = entity_reader(OffsetFetchRequestGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequestGroup))
 @settings(max_examples=1)
 def test_offset_fetch_request_group_roundtrip(
@@ -49,6 +52,7 @@ def test_offset_fetch_request_group_roundtrip(
 read_offset_fetch_request: Final = entity_reader(OffsetFetchRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchRequest))
 @settings(max_examples=1)
 def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
@@ -60,6 +64,7 @@ def test_offset_fetch_request_roundtrip(instance: OffsetFetchRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchRequest))
 def test_offset_fetch_request_java(
     instance: OffsetFetchRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_fetch_v8_response.py
+++ b/tests/generated/test_offset_fetch_v8_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_offset_fetch_response_partitions: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponsePartitions))
 @settings(max_examples=1)
 def test_offset_fetch_response_partitions_roundtrip(
@@ -36,6 +38,7 @@ def test_offset_fetch_response_partitions_roundtrip(
 read_offset_fetch_response_topics: Final = entity_reader(OffsetFetchResponseTopics)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseTopics))
 @settings(max_examples=1)
 def test_offset_fetch_response_topics_roundtrip(
@@ -52,6 +55,7 @@ def test_offset_fetch_response_topics_roundtrip(
 read_offset_fetch_response_group: Final = entity_reader(OffsetFetchResponseGroup)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponseGroup))
 @settings(max_examples=1)
 def test_offset_fetch_response_group_roundtrip(
@@ -68,6 +72,7 @@ def test_offset_fetch_response_group_roundtrip(
 read_offset_fetch_response: Final = entity_reader(OffsetFetchResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetFetchResponse))
 @settings(max_examples=1)
 def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
@@ -79,6 +84,7 @@ def test_offset_fetch_response_roundtrip(instance: OffsetFetchResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetFetchResponse))
 def test_offset_fetch_response_java(
     instance: OffsetFetchResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v0_request.py
+++ b/tests/generated/test_offset_for_leader_epoch_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_offset_for_leader_partition: Final = entity_reader(OffsetForLeaderPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderPartition))
 @settings(max_examples=1)
 def test_offset_for_leader_partition_roundtrip(
@@ -33,6 +35,7 @@ def test_offset_for_leader_partition_roundtrip(
 read_offset_for_leader_topic: Final = entity_reader(OffsetForLeaderTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopic))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> None:
@@ -47,6 +50,7 @@ def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> No
 read_offset_for_leader_epoch_request: Final = entity_reader(OffsetForLeaderEpochRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochRequest))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_request_roundtrip(
@@ -60,6 +64,7 @@ def test_offset_for_leader_epoch_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochRequest))
 def test_offset_for_leader_epoch_request_java(
     instance: OffsetForLeaderEpochRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v0_response.py
+++ b/tests/generated/test_offset_for_leader_epoch_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -31,6 +33,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_offset_for_leader_topic_result: Final = entity_reader(OffsetForLeaderTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopicResult))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_result_roundtrip(
@@ -49,6 +52,7 @@ read_offset_for_leader_epoch_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochResponse))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_response_roundtrip(
@@ -62,6 +66,7 @@ def test_offset_for_leader_epoch_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochResponse))
 def test_offset_for_leader_epoch_response_java(
     instance: OffsetForLeaderEpochResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v1_request.py
+++ b/tests/generated/test_offset_for_leader_epoch_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_offset_for_leader_partition: Final = entity_reader(OffsetForLeaderPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderPartition))
 @settings(max_examples=1)
 def test_offset_for_leader_partition_roundtrip(
@@ -33,6 +35,7 @@ def test_offset_for_leader_partition_roundtrip(
 read_offset_for_leader_topic: Final = entity_reader(OffsetForLeaderTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopic))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> None:
@@ -47,6 +50,7 @@ def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> No
 read_offset_for_leader_epoch_request: Final = entity_reader(OffsetForLeaderEpochRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochRequest))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_request_roundtrip(
@@ -60,6 +64,7 @@ def test_offset_for_leader_epoch_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochRequest))
 def test_offset_for_leader_epoch_request_java(
     instance: OffsetForLeaderEpochRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v1_response.py
+++ b/tests/generated/test_offset_for_leader_epoch_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -31,6 +33,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_offset_for_leader_topic_result: Final = entity_reader(OffsetForLeaderTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopicResult))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_result_roundtrip(
@@ -49,6 +52,7 @@ read_offset_for_leader_epoch_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochResponse))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_response_roundtrip(
@@ -62,6 +66,7 @@ def test_offset_for_leader_epoch_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochResponse))
 def test_offset_for_leader_epoch_response_java(
     instance: OffsetForLeaderEpochResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v2_request.py
+++ b/tests/generated/test_offset_for_leader_epoch_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_offset_for_leader_partition: Final = entity_reader(OffsetForLeaderPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderPartition))
 @settings(max_examples=1)
 def test_offset_for_leader_partition_roundtrip(
@@ -33,6 +35,7 @@ def test_offset_for_leader_partition_roundtrip(
 read_offset_for_leader_topic: Final = entity_reader(OffsetForLeaderTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopic))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> None:
@@ -47,6 +50,7 @@ def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> No
 read_offset_for_leader_epoch_request: Final = entity_reader(OffsetForLeaderEpochRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochRequest))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_request_roundtrip(
@@ -60,6 +64,7 @@ def test_offset_for_leader_epoch_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochRequest))
 def test_offset_for_leader_epoch_request_java(
     instance: OffsetForLeaderEpochRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v2_response.py
+++ b/tests/generated/test_offset_for_leader_epoch_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -31,6 +33,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_offset_for_leader_topic_result: Final = entity_reader(OffsetForLeaderTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopicResult))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_result_roundtrip(
@@ -49,6 +52,7 @@ read_offset_for_leader_epoch_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochResponse))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_response_roundtrip(
@@ -62,6 +66,7 @@ def test_offset_for_leader_epoch_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochResponse))
 def test_offset_for_leader_epoch_response_java(
     instance: OffsetForLeaderEpochResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v3_request.py
+++ b/tests/generated/test_offset_for_leader_epoch_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_offset_for_leader_partition: Final = entity_reader(OffsetForLeaderPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderPartition))
 @settings(max_examples=1)
 def test_offset_for_leader_partition_roundtrip(
@@ -33,6 +35,7 @@ def test_offset_for_leader_partition_roundtrip(
 read_offset_for_leader_topic: Final = entity_reader(OffsetForLeaderTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopic))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> None:
@@ -47,6 +50,7 @@ def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> No
 read_offset_for_leader_epoch_request: Final = entity_reader(OffsetForLeaderEpochRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochRequest))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_request_roundtrip(
@@ -60,6 +64,7 @@ def test_offset_for_leader_epoch_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochRequest))
 def test_offset_for_leader_epoch_request_java(
     instance: OffsetForLeaderEpochRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v3_response.py
+++ b/tests/generated/test_offset_for_leader_epoch_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -31,6 +33,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_offset_for_leader_topic_result: Final = entity_reader(OffsetForLeaderTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopicResult))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_result_roundtrip(
@@ -49,6 +52,7 @@ read_offset_for_leader_epoch_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochResponse))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_response_roundtrip(
@@ -62,6 +66,7 @@ def test_offset_for_leader_epoch_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochResponse))
 def test_offset_for_leader_epoch_response_java(
     instance: OffsetForLeaderEpochResponse, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v4_request.py
+++ b/tests/generated/test_offset_for_leader_epoch_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_offset_for_leader_partition: Final = entity_reader(OffsetForLeaderPartition)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderPartition))
 @settings(max_examples=1)
 def test_offset_for_leader_partition_roundtrip(
@@ -33,6 +35,7 @@ def test_offset_for_leader_partition_roundtrip(
 read_offset_for_leader_topic: Final = entity_reader(OffsetForLeaderTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopic))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> None:
@@ -47,6 +50,7 @@ def test_offset_for_leader_topic_roundtrip(instance: OffsetForLeaderTopic) -> No
 read_offset_for_leader_epoch_request: Final = entity_reader(OffsetForLeaderEpochRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochRequest))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_request_roundtrip(
@@ -60,6 +64,7 @@ def test_offset_for_leader_epoch_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochRequest))
 def test_offset_for_leader_epoch_request_java(
     instance: OffsetForLeaderEpochRequest, java_tester: JavaTester

--- a/tests/generated/test_offset_for_leader_epoch_v4_response.py
+++ b/tests/generated/test_offset_for_leader_epoch_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_epoch_end_offset: Final = entity_reader(EpochEndOffset)
 
 
+@pytest.mark.roundtrip
 @given(from_type(EpochEndOffset))
 @settings(max_examples=1)
 def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
@@ -31,6 +33,7 @@ def test_epoch_end_offset_roundtrip(instance: EpochEndOffset) -> None:
 read_offset_for_leader_topic_result: Final = entity_reader(OffsetForLeaderTopicResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderTopicResult))
 @settings(max_examples=1)
 def test_offset_for_leader_topic_result_roundtrip(
@@ -49,6 +52,7 @@ read_offset_for_leader_epoch_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(OffsetForLeaderEpochResponse))
 @settings(max_examples=1)
 def test_offset_for_leader_epoch_response_roundtrip(
@@ -62,6 +66,7 @@ def test_offset_for_leader_epoch_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(OffsetForLeaderEpochResponse))
 def test_offset_for_leader_epoch_response_java(
     instance: OffsetForLeaderEpochResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v0_request.py
+++ b/tests/generated/test_produce_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v0_response.py
+++ b/tests/generated/test_produce_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -33,6 +35,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -47,6 +50,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -58,6 +62,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v1_request.py
+++ b/tests/generated/test_produce_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v1_response.py
+++ b/tests/generated/test_produce_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -33,6 +35,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -47,6 +50,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -58,6 +62,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v2_request.py
+++ b/tests/generated/test_produce_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v2_response.py
+++ b/tests/generated/test_produce_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -33,6 +35,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -47,6 +50,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -58,6 +62,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v3_request.py
+++ b/tests/generated/test_produce_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v3_response.py
+++ b/tests/generated/test_produce_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -33,6 +35,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -47,6 +50,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -58,6 +62,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v4_request.py
+++ b/tests/generated/test_produce_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v4_response.py
+++ b/tests/generated/test_produce_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -33,6 +35,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -47,6 +50,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -58,6 +62,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v5_request.py
+++ b/tests/generated/test_produce_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v5_response.py
+++ b/tests/generated/test_produce_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -33,6 +35,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -47,6 +50,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -58,6 +62,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v6_request.py
+++ b/tests/generated/test_produce_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v6_response.py
+++ b/tests/generated/test_produce_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -33,6 +35,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -47,6 +50,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -58,6 +62,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v7_request.py
+++ b/tests/generated/test_produce_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v7_response.py
+++ b/tests/generated/test_produce_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -33,6 +35,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -47,6 +50,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -58,6 +62,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v8_request.py
+++ b/tests/generated/test_produce_v8_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v8_response.py
+++ b/tests/generated/test_produce_v8_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_batch_index_and_error_message: Final = entity_reader(BatchIndexAndErrorMessage)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BatchIndexAndErrorMessage))
 @settings(max_examples=1)
 def test_batch_index_and_error_message_roundtrip(
@@ -34,6 +36,7 @@ def test_batch_index_and_error_message_roundtrip(
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -50,6 +53,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -64,6 +68,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -75,6 +80,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_produce_v9_request.py
+++ b/tests/generated/test_produce_v9_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_partition_produce_data: Final = entity_reader(PartitionProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceData))
 @settings(max_examples=1)
 def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> None:
@@ -30,6 +32,7 @@ def test_partition_produce_data_roundtrip(instance: PartitionProduceData) -> Non
 read_topic_produce_data: Final = entity_reader(TopicProduceData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceData))
 @settings(max_examples=1)
 def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
@@ -44,6 +47,7 @@ def test_topic_produce_data_roundtrip(instance: TopicProduceData) -> None:
 read_produce_request: Final = entity_reader(ProduceRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceRequest))
 @settings(max_examples=1)
 def test_produce_request_roundtrip(instance: ProduceRequest) -> None:

--- a/tests/generated/test_produce_v9_response.py
+++ b/tests/generated/test_produce_v9_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -18,6 +19,7 @@ from tests.conftest import setup_buffer
 read_batch_index_and_error_message: Final = entity_reader(BatchIndexAndErrorMessage)
 
 
+@pytest.mark.roundtrip
 @given(from_type(BatchIndexAndErrorMessage))
 @settings(max_examples=1)
 def test_batch_index_and_error_message_roundtrip(
@@ -34,6 +36,7 @@ def test_batch_index_and_error_message_roundtrip(
 read_partition_produce_response: Final = entity_reader(PartitionProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionProduceResponse))
 @settings(max_examples=1)
 def test_partition_produce_response_roundtrip(
@@ -50,6 +53,7 @@ def test_partition_produce_response_roundtrip(
 read_topic_produce_response: Final = entity_reader(TopicProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicProduceResponse))
 @settings(max_examples=1)
 def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> None:
@@ -64,6 +68,7 @@ def test_topic_produce_response_roundtrip(instance: TopicProduceResponse) -> Non
 read_produce_response: Final = entity_reader(ProduceResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ProduceResponse))
 @settings(max_examples=1)
 def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
@@ -75,6 +80,7 @@ def test_produce_response_roundtrip(instance: ProduceResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ProduceResponse))
 def test_produce_response_java(
     instance: ProduceResponse, java_tester: JavaTester

--- a/tests/generated/test_renew_delegation_token_v0_request.py
+++ b/tests/generated/test_renew_delegation_token_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_renew_delegation_token_request: Final = entity_reader(RenewDelegationTokenRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RenewDelegationTokenRequest))
 @settings(max_examples=1)
 def test_renew_delegation_token_request_roundtrip(
@@ -28,6 +30,7 @@ def test_renew_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RenewDelegationTokenRequest))
 def test_renew_delegation_token_request_java(
     instance: RenewDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_renew_delegation_token_v0_response.py
+++ b/tests/generated/test_renew_delegation_token_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_renew_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(RenewDelegationTokenResponse))
 @settings(max_examples=1)
 def test_renew_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_renew_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RenewDelegationTokenResponse))
 def test_renew_delegation_token_response_java(
     instance: RenewDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_renew_delegation_token_v1_request.py
+++ b/tests/generated/test_renew_delegation_token_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_renew_delegation_token_request: Final = entity_reader(RenewDelegationTokenRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RenewDelegationTokenRequest))
 @settings(max_examples=1)
 def test_renew_delegation_token_request_roundtrip(
@@ -28,6 +30,7 @@ def test_renew_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RenewDelegationTokenRequest))
 def test_renew_delegation_token_request_java(
     instance: RenewDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_renew_delegation_token_v1_response.py
+++ b/tests/generated/test_renew_delegation_token_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_renew_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(RenewDelegationTokenResponse))
 @settings(max_examples=1)
 def test_renew_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_renew_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RenewDelegationTokenResponse))
 def test_renew_delegation_token_response_java(
     instance: RenewDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_renew_delegation_token_v2_request.py
+++ b/tests/generated/test_renew_delegation_token_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_renew_delegation_token_request: Final = entity_reader(RenewDelegationTokenRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RenewDelegationTokenRequest))
 @settings(max_examples=1)
 def test_renew_delegation_token_request_roundtrip(
@@ -28,6 +30,7 @@ def test_renew_delegation_token_request_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RenewDelegationTokenRequest))
 def test_renew_delegation_token_request_java(
     instance: RenewDelegationTokenRequest, java_tester: JavaTester

--- a/tests/generated/test_renew_delegation_token_v2_response.py
+++ b/tests/generated/test_renew_delegation_token_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ read_renew_delegation_token_response: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(RenewDelegationTokenResponse))
 @settings(max_examples=1)
 def test_renew_delegation_token_response_roundtrip(
@@ -30,6 +32,7 @@ def test_renew_delegation_token_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RenewDelegationTokenResponse))
 def test_renew_delegation_token_response_java(
     instance: RenewDelegationTokenResponse, java_tester: JavaTester

--- a/tests/generated/test_request_header_v0_header.py
+++ b/tests/generated/test_request_header_v0_header.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_request_header: Final = entity_reader(RequestHeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RequestHeader))
 @settings(max_examples=1)
 def test_request_header_roundtrip(instance: RequestHeader) -> None:
@@ -26,6 +28,7 @@ def test_request_header_roundtrip(instance: RequestHeader) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RequestHeader))
 def test_request_header_java(instance: RequestHeader, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_request_header_v1_header.py
+++ b/tests/generated/test_request_header_v1_header.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_request_header: Final = entity_reader(RequestHeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RequestHeader))
 @settings(max_examples=1)
 def test_request_header_roundtrip(instance: RequestHeader) -> None:
@@ -26,6 +28,7 @@ def test_request_header_roundtrip(instance: RequestHeader) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RequestHeader))
 def test_request_header_java(instance: RequestHeader, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_request_header_v2_header.py
+++ b/tests/generated/test_request_header_v2_header.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_request_header: Final = entity_reader(RequestHeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(RequestHeader))
 @settings(max_examples=1)
 def test_request_header_roundtrip(instance: RequestHeader) -> None:
@@ -26,6 +28,7 @@ def test_request_header_roundtrip(instance: RequestHeader) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(RequestHeader))
 def test_request_header_java(instance: RequestHeader, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_response_header_v0_header.py
+++ b/tests/generated/test_response_header_v0_header.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_response_header: Final = entity_reader(ResponseHeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ResponseHeader))
 @settings(max_examples=1)
 def test_response_header_roundtrip(instance: ResponseHeader) -> None:
@@ -26,6 +28,7 @@ def test_response_header_roundtrip(instance: ResponseHeader) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ResponseHeader))
 def test_response_header_java(
     instance: ResponseHeader, java_tester: JavaTester

--- a/tests/generated/test_response_header_v1_header.py
+++ b/tests/generated/test_response_header_v1_header.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_response_header: Final = entity_reader(ResponseHeader)
 
 
+@pytest.mark.roundtrip
 @given(from_type(ResponseHeader))
 @settings(max_examples=1)
 def test_response_header_roundtrip(instance: ResponseHeader) -> None:
@@ -26,6 +28,7 @@ def test_response_header_roundtrip(instance: ResponseHeader) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(ResponseHeader))
 def test_response_header_java(
     instance: ResponseHeader, java_tester: JavaTester

--- a/tests/generated/test_sasl_authenticate_v0_request.py
+++ b/tests/generated/test_sasl_authenticate_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_authenticate_request: Final = entity_reader(SaslAuthenticateRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslAuthenticateRequest))
 @settings(max_examples=1)
 def test_sasl_authenticate_request_roundtrip(instance: SaslAuthenticateRequest) -> None:
@@ -26,6 +28,7 @@ def test_sasl_authenticate_request_roundtrip(instance: SaslAuthenticateRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslAuthenticateRequest))
 def test_sasl_authenticate_request_java(
     instance: SaslAuthenticateRequest, java_tester: JavaTester

--- a/tests/generated/test_sasl_authenticate_v0_response.py
+++ b/tests/generated/test_sasl_authenticate_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_authenticate_response: Final = entity_reader(SaslAuthenticateResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslAuthenticateResponse))
 @settings(max_examples=1)
 def test_sasl_authenticate_response_roundtrip(
@@ -28,6 +30,7 @@ def test_sasl_authenticate_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslAuthenticateResponse))
 def test_sasl_authenticate_response_java(
     instance: SaslAuthenticateResponse, java_tester: JavaTester

--- a/tests/generated/test_sasl_authenticate_v1_request.py
+++ b/tests/generated/test_sasl_authenticate_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_authenticate_request: Final = entity_reader(SaslAuthenticateRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslAuthenticateRequest))
 @settings(max_examples=1)
 def test_sasl_authenticate_request_roundtrip(instance: SaslAuthenticateRequest) -> None:
@@ -26,6 +28,7 @@ def test_sasl_authenticate_request_roundtrip(instance: SaslAuthenticateRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslAuthenticateRequest))
 def test_sasl_authenticate_request_java(
     instance: SaslAuthenticateRequest, java_tester: JavaTester

--- a/tests/generated/test_sasl_authenticate_v1_response.py
+++ b/tests/generated/test_sasl_authenticate_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_authenticate_response: Final = entity_reader(SaslAuthenticateResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslAuthenticateResponse))
 @settings(max_examples=1)
 def test_sasl_authenticate_response_roundtrip(
@@ -28,6 +30,7 @@ def test_sasl_authenticate_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslAuthenticateResponse))
 def test_sasl_authenticate_response_java(
     instance: SaslAuthenticateResponse, java_tester: JavaTester

--- a/tests/generated/test_sasl_authenticate_v2_request.py
+++ b/tests/generated/test_sasl_authenticate_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_authenticate_request: Final = entity_reader(SaslAuthenticateRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslAuthenticateRequest))
 @settings(max_examples=1)
 def test_sasl_authenticate_request_roundtrip(instance: SaslAuthenticateRequest) -> None:
@@ -26,6 +28,7 @@ def test_sasl_authenticate_request_roundtrip(instance: SaslAuthenticateRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslAuthenticateRequest))
 def test_sasl_authenticate_request_java(
     instance: SaslAuthenticateRequest, java_tester: JavaTester

--- a/tests/generated/test_sasl_authenticate_v2_response.py
+++ b/tests/generated/test_sasl_authenticate_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_authenticate_response: Final = entity_reader(SaslAuthenticateResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslAuthenticateResponse))
 @settings(max_examples=1)
 def test_sasl_authenticate_response_roundtrip(
@@ -28,6 +30,7 @@ def test_sasl_authenticate_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslAuthenticateResponse))
 def test_sasl_authenticate_response_java(
     instance: SaslAuthenticateResponse, java_tester: JavaTester

--- a/tests/generated/test_sasl_handshake_v0_request.py
+++ b/tests/generated/test_sasl_handshake_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_handshake_request: Final = entity_reader(SaslHandshakeRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslHandshakeRequest))
 @settings(max_examples=1)
 def test_sasl_handshake_request_roundtrip(instance: SaslHandshakeRequest) -> None:
@@ -26,6 +28,7 @@ def test_sasl_handshake_request_roundtrip(instance: SaslHandshakeRequest) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslHandshakeRequest))
 def test_sasl_handshake_request_java(
     instance: SaslHandshakeRequest, java_tester: JavaTester

--- a/tests/generated/test_sasl_handshake_v0_response.py
+++ b/tests/generated/test_sasl_handshake_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_handshake_response: Final = entity_reader(SaslHandshakeResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslHandshakeResponse))
 @settings(max_examples=1)
 def test_sasl_handshake_response_roundtrip(instance: SaslHandshakeResponse) -> None:
@@ -26,6 +28,7 @@ def test_sasl_handshake_response_roundtrip(instance: SaslHandshakeResponse) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslHandshakeResponse))
 def test_sasl_handshake_response_java(
     instance: SaslHandshakeResponse, java_tester: JavaTester

--- a/tests/generated/test_sasl_handshake_v1_request.py
+++ b/tests/generated/test_sasl_handshake_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_handshake_request: Final = entity_reader(SaslHandshakeRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslHandshakeRequest))
 @settings(max_examples=1)
 def test_sasl_handshake_request_roundtrip(instance: SaslHandshakeRequest) -> None:
@@ -26,6 +28,7 @@ def test_sasl_handshake_request_roundtrip(instance: SaslHandshakeRequest) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslHandshakeRequest))
 def test_sasl_handshake_request_java(
     instance: SaslHandshakeRequest, java_tester: JavaTester

--- a/tests/generated/test_sasl_handshake_v1_response.py
+++ b/tests/generated/test_sasl_handshake_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sasl_handshake_response: Final = entity_reader(SaslHandshakeResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SaslHandshakeResponse))
 @settings(max_examples=1)
 def test_sasl_handshake_response_roundtrip(instance: SaslHandshakeResponse) -> None:
@@ -26,6 +28,7 @@ def test_sasl_handshake_response_roundtrip(instance: SaslHandshakeResponse) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SaslHandshakeResponse))
 def test_sasl_handshake_response_java(
     instance: SaslHandshakeResponse, java_tester: JavaTester

--- a/tests/generated/test_snapshot_footer_record_v0_data.py
+++ b/tests/generated/test_snapshot_footer_record_v0_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_snapshot_footer_record: Final = entity_reader(SnapshotFooterRecord)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SnapshotFooterRecord))
 @settings(max_examples=1)
 def test_snapshot_footer_record_roundtrip(instance: SnapshotFooterRecord) -> None:
@@ -26,6 +28,7 @@ def test_snapshot_footer_record_roundtrip(instance: SnapshotFooterRecord) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SnapshotFooterRecord))
 def test_snapshot_footer_record_java(
     instance: SnapshotFooterRecord, java_tester: JavaTester

--- a/tests/generated/test_snapshot_header_record_v0_data.py
+++ b/tests/generated/test_snapshot_header_record_v0_data.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_snapshot_header_record: Final = entity_reader(SnapshotHeaderRecord)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SnapshotHeaderRecord))
 @settings(max_examples=1)
 def test_snapshot_header_record_roundtrip(instance: SnapshotHeaderRecord) -> None:
@@ -26,6 +28,7 @@ def test_snapshot_header_record_roundtrip(instance: SnapshotHeaderRecord) -> Non
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SnapshotHeaderRecord))
 def test_snapshot_header_record_java(
     instance: SnapshotHeaderRecord, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v0_request.py
+++ b/tests/generated/test_stop_replica_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_partition_v0: Final = entity_reader(StopReplicaPartitionV0)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaPartitionV0))
 @settings(max_examples=1)
 def test_stop_replica_partition_v0_roundtrip(instance: StopReplicaPartitionV0) -> None:
@@ -30,6 +32,7 @@ def test_stop_replica_partition_v0_roundtrip(instance: StopReplicaPartitionV0) -
 read_stop_replica_request: Final = entity_reader(StopReplicaRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaRequest))
 @settings(max_examples=1)
 def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
@@ -41,6 +44,7 @@ def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaRequest))
 def test_stop_replica_request_java(
     instance: StopReplicaRequest, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v0_response.py
+++ b/tests/generated/test_stop_replica_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_partition_error: Final = entity_reader(StopReplicaPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaPartitionError))
 @settings(max_examples=1)
 def test_stop_replica_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_stop_replica_partition_error_roundtrip(
 read_stop_replica_response: Final = entity_reader(StopReplicaResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaResponse))
 @settings(max_examples=1)
 def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
@@ -43,6 +46,7 @@ def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaResponse))
 def test_stop_replica_response_java(
     instance: StopReplicaResponse, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v1_request.py
+++ b/tests/generated/test_stop_replica_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_topic_v1: Final = entity_reader(StopReplicaTopicV1)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaTopicV1))
 @settings(max_examples=1)
 def test_stop_replica_topic_v1_roundtrip(instance: StopReplicaTopicV1) -> None:
@@ -30,6 +32,7 @@ def test_stop_replica_topic_v1_roundtrip(instance: StopReplicaTopicV1) -> None:
 read_stop_replica_request: Final = entity_reader(StopReplicaRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaRequest))
 @settings(max_examples=1)
 def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
@@ -41,6 +44,7 @@ def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaRequest))
 def test_stop_replica_request_java(
     instance: StopReplicaRequest, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v1_response.py
+++ b/tests/generated/test_stop_replica_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_partition_error: Final = entity_reader(StopReplicaPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaPartitionError))
 @settings(max_examples=1)
 def test_stop_replica_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_stop_replica_partition_error_roundtrip(
 read_stop_replica_response: Final = entity_reader(StopReplicaResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaResponse))
 @settings(max_examples=1)
 def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
@@ -43,6 +46,7 @@ def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaResponse))
 def test_stop_replica_response_java(
     instance: StopReplicaResponse, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v2_request.py
+++ b/tests/generated/test_stop_replica_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_topic_v1: Final = entity_reader(StopReplicaTopicV1)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaTopicV1))
 @settings(max_examples=1)
 def test_stop_replica_topic_v1_roundtrip(instance: StopReplicaTopicV1) -> None:
@@ -30,6 +32,7 @@ def test_stop_replica_topic_v1_roundtrip(instance: StopReplicaTopicV1) -> None:
 read_stop_replica_request: Final = entity_reader(StopReplicaRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaRequest))
 @settings(max_examples=1)
 def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
@@ -41,6 +44,7 @@ def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaRequest))
 def test_stop_replica_request_java(
     instance: StopReplicaRequest, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v2_response.py
+++ b/tests/generated/test_stop_replica_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_partition_error: Final = entity_reader(StopReplicaPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaPartitionError))
 @settings(max_examples=1)
 def test_stop_replica_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_stop_replica_partition_error_roundtrip(
 read_stop_replica_response: Final = entity_reader(StopReplicaResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaResponse))
 @settings(max_examples=1)
 def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
@@ -43,6 +46,7 @@ def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaResponse))
 def test_stop_replica_response_java(
     instance: StopReplicaResponse, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v3_request.py
+++ b/tests/generated/test_stop_replica_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_partition_state: Final = entity_reader(StopReplicaPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaPartitionState))
 @settings(max_examples=1)
 def test_stop_replica_partition_state_roundtrip(
@@ -33,6 +35,7 @@ def test_stop_replica_partition_state_roundtrip(
 read_stop_replica_topic_state: Final = entity_reader(StopReplicaTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaTopicState))
 @settings(max_examples=1)
 def test_stop_replica_topic_state_roundtrip(instance: StopReplicaTopicState) -> None:
@@ -47,6 +50,7 @@ def test_stop_replica_topic_state_roundtrip(instance: StopReplicaTopicState) -> 
 read_stop_replica_request: Final = entity_reader(StopReplicaRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaRequest))
 @settings(max_examples=1)
 def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
@@ -58,6 +62,7 @@ def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaRequest))
 def test_stop_replica_request_java(
     instance: StopReplicaRequest, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v3_response.py
+++ b/tests/generated/test_stop_replica_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_partition_error: Final = entity_reader(StopReplicaPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaPartitionError))
 @settings(max_examples=1)
 def test_stop_replica_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_stop_replica_partition_error_roundtrip(
 read_stop_replica_response: Final = entity_reader(StopReplicaResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaResponse))
 @settings(max_examples=1)
 def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
@@ -43,6 +46,7 @@ def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaResponse))
 def test_stop_replica_response_java(
     instance: StopReplicaResponse, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v4_request.py
+++ b/tests/generated/test_stop_replica_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_partition_state: Final = entity_reader(StopReplicaPartitionState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaPartitionState))
 @settings(max_examples=1)
 def test_stop_replica_partition_state_roundtrip(
@@ -33,6 +35,7 @@ def test_stop_replica_partition_state_roundtrip(
 read_stop_replica_topic_state: Final = entity_reader(StopReplicaTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaTopicState))
 @settings(max_examples=1)
 def test_stop_replica_topic_state_roundtrip(instance: StopReplicaTopicState) -> None:
@@ -47,6 +50,7 @@ def test_stop_replica_topic_state_roundtrip(instance: StopReplicaTopicState) -> 
 read_stop_replica_request: Final = entity_reader(StopReplicaRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaRequest))
 @settings(max_examples=1)
 def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
@@ -58,6 +62,7 @@ def test_stop_replica_request_roundtrip(instance: StopReplicaRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaRequest))
 def test_stop_replica_request_java(
     instance: StopReplicaRequest, java_tester: JavaTester

--- a/tests/generated/test_stop_replica_v4_response.py
+++ b/tests/generated/test_stop_replica_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_stop_replica_partition_error: Final = entity_reader(StopReplicaPartitionError)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaPartitionError))
 @settings(max_examples=1)
 def test_stop_replica_partition_error_roundtrip(
@@ -32,6 +34,7 @@ def test_stop_replica_partition_error_roundtrip(
 read_stop_replica_response: Final = entity_reader(StopReplicaResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(StopReplicaResponse))
 @settings(max_examples=1)
 def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
@@ -43,6 +46,7 @@ def test_stop_replica_response_roundtrip(instance: StopReplicaResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(StopReplicaResponse))
 def test_stop_replica_response_java(
     instance: StopReplicaResponse, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v0_request.py
+++ b/tests/generated/test_sync_group_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_sync_group_request_assignment: Final = entity_reader(SyncGroupRequestAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequestAssignment))
 @settings(max_examples=1)
 def test_sync_group_request_assignment_roundtrip(
@@ -32,6 +34,7 @@ def test_sync_group_request_assignment_roundtrip(
 read_sync_group_request: Final = entity_reader(SyncGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequest))
 @settings(max_examples=1)
 def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupRequest))
 def test_sync_group_request_java(
     instance: SyncGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v0_response.py
+++ b/tests/generated/test_sync_group_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sync_group_response: Final = entity_reader(SyncGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupResponse))
 @settings(max_examples=1)
 def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupResponse))
 def test_sync_group_response_java(
     instance: SyncGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v1_request.py
+++ b/tests/generated/test_sync_group_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_sync_group_request_assignment: Final = entity_reader(SyncGroupRequestAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequestAssignment))
 @settings(max_examples=1)
 def test_sync_group_request_assignment_roundtrip(
@@ -32,6 +34,7 @@ def test_sync_group_request_assignment_roundtrip(
 read_sync_group_request: Final = entity_reader(SyncGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequest))
 @settings(max_examples=1)
 def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupRequest))
 def test_sync_group_request_java(
     instance: SyncGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v1_response.py
+++ b/tests/generated/test_sync_group_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sync_group_response: Final = entity_reader(SyncGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupResponse))
 @settings(max_examples=1)
 def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupResponse))
 def test_sync_group_response_java(
     instance: SyncGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v2_request.py
+++ b/tests/generated/test_sync_group_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_sync_group_request_assignment: Final = entity_reader(SyncGroupRequestAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequestAssignment))
 @settings(max_examples=1)
 def test_sync_group_request_assignment_roundtrip(
@@ -32,6 +34,7 @@ def test_sync_group_request_assignment_roundtrip(
 read_sync_group_request: Final = entity_reader(SyncGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequest))
 @settings(max_examples=1)
 def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupRequest))
 def test_sync_group_request_java(
     instance: SyncGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v2_response.py
+++ b/tests/generated/test_sync_group_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sync_group_response: Final = entity_reader(SyncGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupResponse))
 @settings(max_examples=1)
 def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupResponse))
 def test_sync_group_response_java(
     instance: SyncGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v3_request.py
+++ b/tests/generated/test_sync_group_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_sync_group_request_assignment: Final = entity_reader(SyncGroupRequestAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequestAssignment))
 @settings(max_examples=1)
 def test_sync_group_request_assignment_roundtrip(
@@ -32,6 +34,7 @@ def test_sync_group_request_assignment_roundtrip(
 read_sync_group_request: Final = entity_reader(SyncGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequest))
 @settings(max_examples=1)
 def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupRequest))
 def test_sync_group_request_java(
     instance: SyncGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v3_response.py
+++ b/tests/generated/test_sync_group_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sync_group_response: Final = entity_reader(SyncGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupResponse))
 @settings(max_examples=1)
 def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupResponse))
 def test_sync_group_response_java(
     instance: SyncGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v4_request.py
+++ b/tests/generated/test_sync_group_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_sync_group_request_assignment: Final = entity_reader(SyncGroupRequestAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequestAssignment))
 @settings(max_examples=1)
 def test_sync_group_request_assignment_roundtrip(
@@ -32,6 +34,7 @@ def test_sync_group_request_assignment_roundtrip(
 read_sync_group_request: Final = entity_reader(SyncGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequest))
 @settings(max_examples=1)
 def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupRequest))
 def test_sync_group_request_java(
     instance: SyncGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v4_response.py
+++ b/tests/generated/test_sync_group_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sync_group_response: Final = entity_reader(SyncGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupResponse))
 @settings(max_examples=1)
 def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupResponse))
 def test_sync_group_response_java(
     instance: SyncGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v5_request.py
+++ b/tests/generated/test_sync_group_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_sync_group_request_assignment: Final = entity_reader(SyncGroupRequestAssignment)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequestAssignment))
 @settings(max_examples=1)
 def test_sync_group_request_assignment_roundtrip(
@@ -32,6 +34,7 @@ def test_sync_group_request_assignment_roundtrip(
 read_sync_group_request: Final = entity_reader(SyncGroupRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupRequest))
 @settings(max_examples=1)
 def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
@@ -43,6 +46,7 @@ def test_sync_group_request_roundtrip(instance: SyncGroupRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupRequest))
 def test_sync_group_request_java(
     instance: SyncGroupRequest, java_tester: JavaTester

--- a/tests/generated/test_sync_group_v5_response.py
+++ b/tests/generated/test_sync_group_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_sync_group_response: Final = entity_reader(SyncGroupResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(SyncGroupResponse))
 @settings(max_examples=1)
 def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
@@ -26,6 +28,7 @@ def test_sync_group_response_roundtrip(instance: SyncGroupResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(SyncGroupResponse))
 def test_sync_group_response_java(
     instance: SyncGroupResponse, java_tester: JavaTester

--- a/tests/generated/test_txn_offset_commit_v0_request.py
+++ b/tests/generated/test_txn_offset_commit_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_txn_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_txn_offset_commit_request_partition_roundtrip(
 read_txn_offset_commit_request_topic: Final = entity_reader(TxnOffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_txn_offset_commit_request_topic_roundtrip(
 read_txn_offset_commit_request: Final = entity_reader(TxnOffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequest))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_roundtrip(instance: TxnOffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_txn_offset_commit_request_roundtrip(instance: TxnOffsetCommitRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(TxnOffsetCommitRequest))
 def test_txn_offset_commit_request_java(
     instance: TxnOffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_txn_offset_commit_v0_response.py
+++ b/tests/generated/test_txn_offset_commit_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_txn_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_partition_roundtrip(
@@ -37,6 +39,7 @@ read_txn_offset_commit_response_topic: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_topic_roundtrip(
@@ -53,6 +56,7 @@ def test_txn_offset_commit_response_topic_roundtrip(
 read_txn_offset_commit_response: Final = entity_reader(TxnOffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponse))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_roundtrip(
@@ -66,6 +70,7 @@ def test_txn_offset_commit_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(TxnOffsetCommitResponse))
 def test_txn_offset_commit_response_java(
     instance: TxnOffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_txn_offset_commit_v1_request.py
+++ b/tests/generated/test_txn_offset_commit_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_txn_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_txn_offset_commit_request_partition_roundtrip(
 read_txn_offset_commit_request_topic: Final = entity_reader(TxnOffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_txn_offset_commit_request_topic_roundtrip(
 read_txn_offset_commit_request: Final = entity_reader(TxnOffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequest))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_roundtrip(instance: TxnOffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_txn_offset_commit_request_roundtrip(instance: TxnOffsetCommitRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(TxnOffsetCommitRequest))
 def test_txn_offset_commit_request_java(
     instance: TxnOffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_txn_offset_commit_v1_response.py
+++ b/tests/generated/test_txn_offset_commit_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_txn_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_partition_roundtrip(
@@ -37,6 +39,7 @@ read_txn_offset_commit_response_topic: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_topic_roundtrip(
@@ -53,6 +56,7 @@ def test_txn_offset_commit_response_topic_roundtrip(
 read_txn_offset_commit_response: Final = entity_reader(TxnOffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponse))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_roundtrip(
@@ -66,6 +70,7 @@ def test_txn_offset_commit_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(TxnOffsetCommitResponse))
 def test_txn_offset_commit_response_java(
     instance: TxnOffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_txn_offset_commit_v2_request.py
+++ b/tests/generated/test_txn_offset_commit_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_txn_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_txn_offset_commit_request_partition_roundtrip(
 read_txn_offset_commit_request_topic: Final = entity_reader(TxnOffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_txn_offset_commit_request_topic_roundtrip(
 read_txn_offset_commit_request: Final = entity_reader(TxnOffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequest))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_roundtrip(instance: TxnOffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_txn_offset_commit_request_roundtrip(instance: TxnOffsetCommitRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(TxnOffsetCommitRequest))
 def test_txn_offset_commit_request_java(
     instance: TxnOffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_txn_offset_commit_v2_response.py
+++ b/tests/generated/test_txn_offset_commit_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_txn_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_partition_roundtrip(
@@ -37,6 +39,7 @@ read_txn_offset_commit_response_topic: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_topic_roundtrip(
@@ -53,6 +56,7 @@ def test_txn_offset_commit_response_topic_roundtrip(
 read_txn_offset_commit_response: Final = entity_reader(TxnOffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponse))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_roundtrip(
@@ -66,6 +70,7 @@ def test_txn_offset_commit_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(TxnOffsetCommitResponse))
 def test_txn_offset_commit_response_java(
     instance: TxnOffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_txn_offset_commit_v3_request.py
+++ b/tests/generated/test_txn_offset_commit_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_txn_offset_commit_request_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequestPartition))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_partition_roundtrip(
@@ -35,6 +37,7 @@ def test_txn_offset_commit_request_partition_roundtrip(
 read_txn_offset_commit_request_topic: Final = entity_reader(TxnOffsetCommitRequestTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequestTopic))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_topic_roundtrip(
@@ -51,6 +54,7 @@ def test_txn_offset_commit_request_topic_roundtrip(
 read_txn_offset_commit_request: Final = entity_reader(TxnOffsetCommitRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitRequest))
 @settings(max_examples=1)
 def test_txn_offset_commit_request_roundtrip(instance: TxnOffsetCommitRequest) -> None:
@@ -62,6 +66,7 @@ def test_txn_offset_commit_request_roundtrip(instance: TxnOffsetCommitRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(TxnOffsetCommitRequest))
 def test_txn_offset_commit_request_java(
     instance: TxnOffsetCommitRequest, java_tester: JavaTester

--- a/tests/generated/test_txn_offset_commit_v3_response.py
+++ b/tests/generated/test_txn_offset_commit_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_txn_offset_commit_response_partition: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponsePartition))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_partition_roundtrip(
@@ -37,6 +39,7 @@ read_txn_offset_commit_response_topic: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponseTopic))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_topic_roundtrip(
@@ -53,6 +56,7 @@ def test_txn_offset_commit_response_topic_roundtrip(
 read_txn_offset_commit_response: Final = entity_reader(TxnOffsetCommitResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TxnOffsetCommitResponse))
 @settings(max_examples=1)
 def test_txn_offset_commit_response_roundtrip(
@@ -66,6 +70,7 @@ def test_txn_offset_commit_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(TxnOffsetCommitResponse))
 def test_txn_offset_commit_response_java(
     instance: TxnOffsetCommitResponse, java_tester: JavaTester

--- a/tests/generated/test_unregister_broker_v0_request.py
+++ b/tests/generated/test_unregister_broker_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_unregister_broker_request: Final = entity_reader(UnregisterBrokerRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UnregisterBrokerRequest))
 @settings(max_examples=1)
 def test_unregister_broker_request_roundtrip(instance: UnregisterBrokerRequest) -> None:
@@ -26,6 +28,7 @@ def test_unregister_broker_request_roundtrip(instance: UnregisterBrokerRequest) 
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UnregisterBrokerRequest))
 def test_unregister_broker_request_java(
     instance: UnregisterBrokerRequest, java_tester: JavaTester

--- a/tests/generated/test_unregister_broker_v0_response.py
+++ b/tests/generated/test_unregister_broker_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_unregister_broker_response: Final = entity_reader(UnregisterBrokerResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UnregisterBrokerResponse))
 @settings(max_examples=1)
 def test_unregister_broker_response_roundtrip(
@@ -28,6 +30,7 @@ def test_unregister_broker_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UnregisterBrokerResponse))
 def test_unregister_broker_response_java(
     instance: UnregisterBrokerResponse, java_tester: JavaTester

--- a/tests/generated/test_update_features_v0_request.py
+++ b/tests/generated/test_update_features_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_feature_update_key: Final = entity_reader(FeatureUpdateKey)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FeatureUpdateKey))
 @settings(max_examples=1)
 def test_feature_update_key_roundtrip(instance: FeatureUpdateKey) -> None:
@@ -30,6 +32,7 @@ def test_feature_update_key_roundtrip(instance: FeatureUpdateKey) -> None:
 read_update_features_request: Final = entity_reader(UpdateFeaturesRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateFeaturesRequest))
 @settings(max_examples=1)
 def test_update_features_request_roundtrip(instance: UpdateFeaturesRequest) -> None:
@@ -41,6 +44,7 @@ def test_update_features_request_roundtrip(instance: UpdateFeaturesRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateFeaturesRequest))
 def test_update_features_request_java(
     instance: UpdateFeaturesRequest, java_tester: JavaTester

--- a/tests/generated/test_update_features_v0_response.py
+++ b/tests/generated/test_update_features_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_updatable_feature_result: Final = entity_reader(UpdatableFeatureResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdatableFeatureResult))
 @settings(max_examples=1)
 def test_updatable_feature_result_roundtrip(instance: UpdatableFeatureResult) -> None:
@@ -30,6 +32,7 @@ def test_updatable_feature_result_roundtrip(instance: UpdatableFeatureResult) ->
 read_update_features_response: Final = entity_reader(UpdateFeaturesResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateFeaturesResponse))
 @settings(max_examples=1)
 def test_update_features_response_roundtrip(instance: UpdateFeaturesResponse) -> None:
@@ -41,6 +44,7 @@ def test_update_features_response_roundtrip(instance: UpdateFeaturesResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateFeaturesResponse))
 def test_update_features_response_java(
     instance: UpdateFeaturesResponse, java_tester: JavaTester

--- a/tests/generated/test_update_features_v1_request.py
+++ b/tests/generated/test_update_features_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_feature_update_key: Final = entity_reader(FeatureUpdateKey)
 
 
+@pytest.mark.roundtrip
 @given(from_type(FeatureUpdateKey))
 @settings(max_examples=1)
 def test_feature_update_key_roundtrip(instance: FeatureUpdateKey) -> None:
@@ -30,6 +32,7 @@ def test_feature_update_key_roundtrip(instance: FeatureUpdateKey) -> None:
 read_update_features_request: Final = entity_reader(UpdateFeaturesRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateFeaturesRequest))
 @settings(max_examples=1)
 def test_update_features_request_roundtrip(instance: UpdateFeaturesRequest) -> None:
@@ -41,6 +44,7 @@ def test_update_features_request_roundtrip(instance: UpdateFeaturesRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateFeaturesRequest))
 def test_update_features_request_java(
     instance: UpdateFeaturesRequest, java_tester: JavaTester

--- a/tests/generated/test_update_features_v1_response.py
+++ b/tests/generated/test_update_features_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -16,6 +17,7 @@ from tests.conftest import setup_buffer
 read_updatable_feature_result: Final = entity_reader(UpdatableFeatureResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdatableFeatureResult))
 @settings(max_examples=1)
 def test_updatable_feature_result_roundtrip(instance: UpdatableFeatureResult) -> None:
@@ -30,6 +32,7 @@ def test_updatable_feature_result_roundtrip(instance: UpdatableFeatureResult) ->
 read_update_features_response: Final = entity_reader(UpdateFeaturesResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateFeaturesResponse))
 @settings(max_examples=1)
 def test_update_features_response_roundtrip(instance: UpdateFeaturesResponse) -> None:
@@ -41,6 +44,7 @@ def test_update_features_response_roundtrip(instance: UpdateFeaturesResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateFeaturesResponse))
 def test_update_features_response_java(
     instance: UpdateFeaturesResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v0_request.py
+++ b/tests/generated/test_update_metadata_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -19,6 +20,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -35,6 +37,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -49,6 +52,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -60,6 +64,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v0_response.py
+++ b/tests/generated/test_update_metadata_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v1_request.py
+++ b/tests/generated/test_update_metadata_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -36,6 +38,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_endpoint: Final = entity_reader(UpdateMetadataEndpoint)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataEndpoint))
 @settings(max_examples=1)
 def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) -> None:
@@ -50,6 +53,7 @@ def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) ->
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -64,6 +68,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -75,6 +80,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v1_response.py
+++ b/tests/generated/test_update_metadata_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v2_request.py
+++ b/tests/generated/test_update_metadata_v2_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -36,6 +38,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_endpoint: Final = entity_reader(UpdateMetadataEndpoint)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataEndpoint))
 @settings(max_examples=1)
 def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) -> None:
@@ -50,6 +53,7 @@ def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) ->
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -64,6 +68,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -75,6 +80,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v2_response.py
+++ b/tests/generated/test_update_metadata_v2_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v3_request.py
+++ b/tests/generated/test_update_metadata_v3_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -36,6 +38,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_endpoint: Final = entity_reader(UpdateMetadataEndpoint)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataEndpoint))
 @settings(max_examples=1)
 def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) -> None:
@@ -50,6 +53,7 @@ def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) ->
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -64,6 +68,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -75,6 +80,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v3_response.py
+++ b/tests/generated/test_update_metadata_v3_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v4_request.py
+++ b/tests/generated/test_update_metadata_v4_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -36,6 +38,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_endpoint: Final = entity_reader(UpdateMetadataEndpoint)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataEndpoint))
 @settings(max_examples=1)
 def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) -> None:
@@ -50,6 +53,7 @@ def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) ->
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -64,6 +68,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -75,6 +80,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v4_response.py
+++ b/tests/generated/test_update_metadata_v4_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v5_request.py
+++ b/tests/generated/test_update_metadata_v5_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -37,6 +39,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_topic_state: Final = entity_reader(UpdateMetadataTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataTopicState))
 @settings(max_examples=1)
 def test_update_metadata_topic_state_roundtrip(
@@ -53,6 +56,7 @@ def test_update_metadata_topic_state_roundtrip(
 read_update_metadata_endpoint: Final = entity_reader(UpdateMetadataEndpoint)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataEndpoint))
 @settings(max_examples=1)
 def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) -> None:
@@ -67,6 +71,7 @@ def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) ->
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -81,6 +86,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -92,6 +98,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v5_response.py
+++ b/tests/generated/test_update_metadata_v5_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v6_request.py
+++ b/tests/generated/test_update_metadata_v6_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -37,6 +39,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_topic_state: Final = entity_reader(UpdateMetadataTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataTopicState))
 @settings(max_examples=1)
 def test_update_metadata_topic_state_roundtrip(
@@ -53,6 +56,7 @@ def test_update_metadata_topic_state_roundtrip(
 read_update_metadata_endpoint: Final = entity_reader(UpdateMetadataEndpoint)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataEndpoint))
 @settings(max_examples=1)
 def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) -> None:
@@ -67,6 +71,7 @@ def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) ->
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -81,6 +86,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -92,6 +98,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v6_response.py
+++ b/tests/generated/test_update_metadata_v6_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v7_request.py
+++ b/tests/generated/test_update_metadata_v7_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -37,6 +39,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_topic_state: Final = entity_reader(UpdateMetadataTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataTopicState))
 @settings(max_examples=1)
 def test_update_metadata_topic_state_roundtrip(
@@ -53,6 +56,7 @@ def test_update_metadata_topic_state_roundtrip(
 read_update_metadata_endpoint: Final = entity_reader(UpdateMetadataEndpoint)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataEndpoint))
 @settings(max_examples=1)
 def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) -> None:
@@ -67,6 +71,7 @@ def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) ->
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -81,6 +86,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -92,6 +98,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v7_response.py
+++ b/tests/generated/test_update_metadata_v7_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v8_request.py
+++ b/tests/generated/test_update_metadata_v8_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -21,6 +22,7 @@ read_update_metadata_partition_state: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataPartitionState))
 @settings(max_examples=1)
 def test_update_metadata_partition_state_roundtrip(
@@ -37,6 +39,7 @@ def test_update_metadata_partition_state_roundtrip(
 read_update_metadata_topic_state: Final = entity_reader(UpdateMetadataTopicState)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataTopicState))
 @settings(max_examples=1)
 def test_update_metadata_topic_state_roundtrip(
@@ -53,6 +56,7 @@ def test_update_metadata_topic_state_roundtrip(
 read_update_metadata_endpoint: Final = entity_reader(UpdateMetadataEndpoint)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataEndpoint))
 @settings(max_examples=1)
 def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) -> None:
@@ -67,6 +71,7 @@ def test_update_metadata_endpoint_roundtrip(instance: UpdateMetadataEndpoint) ->
 read_update_metadata_broker: Final = entity_reader(UpdateMetadataBroker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataBroker))
 @settings(max_examples=1)
 def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> None:
@@ -81,6 +86,7 @@ def test_update_metadata_broker_roundtrip(instance: UpdateMetadataBroker) -> Non
 read_update_metadata_request: Final = entity_reader(UpdateMetadataRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataRequest))
 @settings(max_examples=1)
 def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> None:
@@ -92,6 +98,7 @@ def test_update_metadata_request_roundtrip(instance: UpdateMetadataRequest) -> N
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataRequest))
 def test_update_metadata_request_java(
     instance: UpdateMetadataRequest, java_tester: JavaTester

--- a/tests/generated/test_update_metadata_v8_response.py
+++ b/tests/generated/test_update_metadata_v8_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -15,6 +16,7 @@ from tests.conftest import setup_buffer
 read_update_metadata_response: Final = entity_reader(UpdateMetadataResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(UpdateMetadataResponse))
 @settings(max_examples=1)
 def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) -> None:
@@ -26,6 +28,7 @@ def test_update_metadata_response_roundtrip(instance: UpdateMetadataResponse) ->
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(UpdateMetadataResponse))
 def test_update_metadata_response_java(
     instance: UpdateMetadataResponse, java_tester: JavaTester

--- a/tests/generated/test_vote_v0_request.py
+++ b/tests/generated/test_vote_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_vote_request: Final = entity_reader(VoteRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(VoteRequest))
 @settings(max_examples=1)
 def test_vote_request_roundtrip(instance: VoteRequest) -> None:
@@ -56,6 +60,7 @@ def test_vote_request_roundtrip(instance: VoteRequest) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(VoteRequest))
 def test_vote_request_java(instance: VoteRequest, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_vote_v0_response.py
+++ b/tests/generated/test_vote_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_partition_data: Final = entity_reader(PartitionData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(PartitionData))
 @settings(max_examples=1)
 def test_partition_data_roundtrip(instance: PartitionData) -> None:
@@ -31,6 +33,7 @@ def test_partition_data_roundtrip(instance: PartitionData) -> None:
 read_topic_data: Final = entity_reader(TopicData)
 
 
+@pytest.mark.roundtrip
 @given(from_type(TopicData))
 @settings(max_examples=1)
 def test_topic_data_roundtrip(instance: TopicData) -> None:
@@ -45,6 +48,7 @@ def test_topic_data_roundtrip(instance: TopicData) -> None:
 read_vote_response: Final = entity_reader(VoteResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(VoteResponse))
 @settings(max_examples=1)
 def test_vote_response_roundtrip(instance: VoteResponse) -> None:
@@ -56,6 +60,7 @@ def test_vote_response_roundtrip(instance: VoteResponse) -> None:
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(VoteResponse))
 def test_vote_response_java(instance: VoteResponse, java_tester: JavaTester) -> None:
     java_tester.test(instance)

--- a/tests/generated/test_write_txn_markers_v0_request.py
+++ b/tests/generated/test_write_txn_markers_v0_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_writable_txn_marker_topic: Final = entity_reader(WritableTxnMarkerTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarkerTopic))
 @settings(max_examples=1)
 def test_writable_txn_marker_topic_roundtrip(instance: WritableTxnMarkerTopic) -> None:
@@ -31,6 +33,7 @@ def test_writable_txn_marker_topic_roundtrip(instance: WritableTxnMarkerTopic) -
 read_writable_txn_marker: Final = entity_reader(WritableTxnMarker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarker))
 @settings(max_examples=1)
 def test_writable_txn_marker_roundtrip(instance: WritableTxnMarker) -> None:
@@ -45,6 +48,7 @@ def test_writable_txn_marker_roundtrip(instance: WritableTxnMarker) -> None:
 read_write_txn_markers_request: Final = entity_reader(WriteTxnMarkersRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WriteTxnMarkersRequest))
 @settings(max_examples=1)
 def test_write_txn_markers_request_roundtrip(instance: WriteTxnMarkersRequest) -> None:
@@ -56,6 +60,7 @@ def test_write_txn_markers_request_roundtrip(instance: WriteTxnMarkersRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(WriteTxnMarkersRequest))
 def test_write_txn_markers_request_java(
     instance: WriteTxnMarkersRequest, java_tester: JavaTester

--- a/tests/generated/test_write_txn_markers_v0_response.py
+++ b/tests/generated/test_write_txn_markers_v0_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_writable_txn_marker_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarkerPartitionResult))
 @settings(max_examples=1)
 def test_writable_txn_marker_partition_result_roundtrip(
@@ -38,6 +40,7 @@ read_writable_txn_marker_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarkerTopicResult))
 @settings(max_examples=1)
 def test_writable_txn_marker_topic_result_roundtrip(
@@ -54,6 +57,7 @@ def test_writable_txn_marker_topic_result_roundtrip(
 read_writable_txn_marker_result: Final = entity_reader(WritableTxnMarkerResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarkerResult))
 @settings(max_examples=1)
 def test_writable_txn_marker_result_roundtrip(
@@ -70,6 +74,7 @@ def test_writable_txn_marker_result_roundtrip(
 read_write_txn_markers_response: Final = entity_reader(WriteTxnMarkersResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WriteTxnMarkersResponse))
 @settings(max_examples=1)
 def test_write_txn_markers_response_roundtrip(
@@ -83,6 +88,7 @@ def test_write_txn_markers_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(WriteTxnMarkersResponse))
 def test_write_txn_markers_response_java(
     instance: WriteTxnMarkersResponse, java_tester: JavaTester

--- a/tests/generated/test_write_txn_markers_v1_request.py
+++ b/tests/generated/test_write_txn_markers_v1_request.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -17,6 +18,7 @@ from tests.conftest import setup_buffer
 read_writable_txn_marker_topic: Final = entity_reader(WritableTxnMarkerTopic)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarkerTopic))
 @settings(max_examples=1)
 def test_writable_txn_marker_topic_roundtrip(instance: WritableTxnMarkerTopic) -> None:
@@ -31,6 +33,7 @@ def test_writable_txn_marker_topic_roundtrip(instance: WritableTxnMarkerTopic) -
 read_writable_txn_marker: Final = entity_reader(WritableTxnMarker)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarker))
 @settings(max_examples=1)
 def test_writable_txn_marker_roundtrip(instance: WritableTxnMarker) -> None:
@@ -45,6 +48,7 @@ def test_writable_txn_marker_roundtrip(instance: WritableTxnMarker) -> None:
 read_write_txn_markers_request: Final = entity_reader(WriteTxnMarkersRequest)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WriteTxnMarkersRequest))
 @settings(max_examples=1)
 def test_write_txn_markers_request_roundtrip(instance: WriteTxnMarkersRequest) -> None:
@@ -56,6 +60,7 @@ def test_write_txn_markers_request_roundtrip(instance: WriteTxnMarkersRequest) -
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(WriteTxnMarkersRequest))
 def test_write_txn_markers_request_java(
     instance: WriteTxnMarkersRequest, java_tester: JavaTester

--- a/tests/generated/test_write_txn_markers_v1_response.py
+++ b/tests/generated/test_write_txn_markers_v1_response.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Final
 
+import pytest
 from hypothesis import given
 from hypothesis import settings
 from hypothesis.strategies import from_type
@@ -20,6 +21,7 @@ read_writable_txn_marker_partition_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarkerPartitionResult))
 @settings(max_examples=1)
 def test_writable_txn_marker_partition_result_roundtrip(
@@ -38,6 +40,7 @@ read_writable_txn_marker_topic_result: Final = entity_reader(
 )
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarkerTopicResult))
 @settings(max_examples=1)
 def test_writable_txn_marker_topic_result_roundtrip(
@@ -54,6 +57,7 @@ def test_writable_txn_marker_topic_result_roundtrip(
 read_writable_txn_marker_result: Final = entity_reader(WritableTxnMarkerResult)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WritableTxnMarkerResult))
 @settings(max_examples=1)
 def test_writable_txn_marker_result_roundtrip(
@@ -70,6 +74,7 @@ def test_writable_txn_marker_result_roundtrip(
 read_write_txn_markers_response: Final = entity_reader(WriteTxnMarkersResponse)
 
 
+@pytest.mark.roundtrip
 @given(from_type(WriteTxnMarkersResponse))
 @settings(max_examples=1)
 def test_write_txn_markers_response_roundtrip(
@@ -83,6 +88,7 @@ def test_write_txn_markers_response_roundtrip(
     assert instance == result
 
 
+@pytest.mark.java
 @given(instance=from_type(WriteTxnMarkersResponse))
 def test_write_txn_markers_response_java(
     instance: WriteTxnMarkersResponse, java_tester: JavaTester

--- a/tests/serial/test_roundtrips.py
+++ b/tests/serial/test_roundtrips.py
@@ -2,6 +2,7 @@ import io
 import uuid
 from typing import TypeVar
 
+import pytest
 from hypothesis import given
 from hypothesis.strategies import binary
 from hypothesis.strategies import booleans
@@ -54,6 +55,8 @@ from kio.serial.writers import write_uint32
 from kio.serial.writers import write_uint64
 from kio.serial.writers import write_unsigned_varint
 from kio.serial.writers import write_uuid
+
+pytestmark = pytest.mark.roundtrip
 
 
 @given(booleans(), booleans())

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -10,6 +10,8 @@ from typing import Final
 from typing import TypeVar
 from unittest import mock
 
+import pytest
+
 import kio.schema.request_header.v0.header
 import kio.schema.request_header.v1.header
 import kio.schema.request_header.v2.header
@@ -45,6 +47,8 @@ from kio.static.primitive import i32
 from kio.static.primitive import i32Timedelta
 from kio.static.protocol import Entity
 from kio.static.protocol import Payload
+
+pytestmark = pytest.mark.integration
 
 timedelta_zero: Final = i32Timedelta.parse(datetime.timedelta())
 


### PR DESCRIPTION
This is for a few reasons:

- It allows making only unit tests count towards the measured test coverage. 
- Gives some visibility into how the separate kinds of tests behave.
- Parallelizes the three slow suites, not in an optimal way, but this might have a small positive effect on total test time.