### PR TITLE
Implement KIP-893 nullable entity fields

### DIFF
--- a/codegen/generate_tests.py
+++ b/codegen/generate_tests.py
@@ -121,7 +121,6 @@ def main() -> None:
             "FetchResponse",  # Records
             "FetchSnapshotResponse",  # Records
             "FetchRequest",  # Should not output tagged field if its value equals to default (presumably)
-            "ConsumerGroupHeartbeatResponse",  # Nullable `assignment` field
         }:
             module_code[module_path].append(
                 test_code_java.format(

--- a/codegen/parser.py
+++ b/codegen/parser.py
@@ -372,6 +372,7 @@ class CommonStructArrayField(_BaseField):
 
 class CommonStructField(_BaseField):
     type: CommonStructType
+    default: Literal["null"] | None = None
 
 
 class EntityArrayField(_BaseField):
@@ -382,6 +383,7 @@ class EntityArrayField(_BaseField):
 class EntityField(_BaseField):
     type: EntityType
     fields: tuple[Field, ...]
+    default: Literal["null"] | None = None
 
 
 class _BaseSchema(BaseModel):

--- a/src/kio/_utils.py
+++ b/src/kio/_utils.py
@@ -1,11 +1,13 @@
+from typing import TYPE_CHECKING
+from typing import Protocol
+from typing import TypeVar
+
+__all__ = ("cache", "DataclassInstance")
+
+
 # Work-around for broken support for cache decorators in
 # https://github.com/python/typeshed/issues/6347
 # https://stackoverflow.com/a/73517689
-from typing import TYPE_CHECKING
-from typing import TypeVar
-
-__all__ = ("cache",)
-
 if TYPE_CHECKING:
     _C = TypeVar("_C")
 
@@ -14,3 +16,11 @@ if TYPE_CHECKING:
 
 else:
     from functools import cache
+
+
+if TYPE_CHECKING:
+    from _typeshed import DataclassInstance
+else:
+
+    class DataclassInstance(Protocol):
+        ...

--- a/src/kio/schema/consumer_group_heartbeat/v0/response.py
+++ b/src/kio/schema/consumer_group_heartbeat/v0/response.py
@@ -68,5 +68,5 @@ class ConsumerGroupHeartbeatResponse(ApiMessage):
     """True if the member should compute the assignment for the group."""
     heartbeat_interval: i32Timedelta = field(metadata={"kafka_type": "timedelta_i32"})
     """The heartbeat interval in milliseconds."""
-    assignment: Assignment
+    assignment: Assignment | None = field(default=None)
     """null if not provided; the assignment otherwise."""

--- a/src/kio/serial/_parse.py
+++ b/src/kio/serial/_parse.py
@@ -121,7 +121,7 @@ def get_field_reader(
             return (  # type: ignore[no-any-return]
                 entity_reader(field_type, nullable=True)  # type: ignore[call-overload]
                 if is_optional(field)
-                else entity_reader(field_type)  # type: ignore[type-var]
+                else entity_reader(field_type, nullable=False)  # type: ignore[call-overload]
             )
         case FieldKind.entity_tuple:
             return array_reader(  # type: ignore[return-value]
@@ -135,7 +135,10 @@ E = TypeVar("E", bound=Entity)
 
 
 @overload
-def entity_reader(entity_type: type[E]) -> readers.Reader[E]:
+def entity_reader(
+    entity_type: type[E],
+    nullable: Literal[False] = ...,
+) -> readers.Reader[E]:
     ...
 
 

--- a/src/kio/serial/_serialize.py
+++ b/src/kio/serial/_serialize.py
@@ -135,7 +135,7 @@ def get_field_writer(
             return (  # type: ignore[no-any-return]
                 entity_writer(field_type, nullable=True)  # type: ignore[call-overload]
                 if optional
-                else entity_writer(field_type)  # type: ignore[type-var]
+                else entity_writer(field_type, nullable=False)  # type: ignore[call-overload]
             )
         case FieldKind.entity_tuple:
             return array_writer(  # type: ignore[return-value]
@@ -162,7 +162,7 @@ def _wrap_nullable(write_entity: Writer[E]) -> Writer[E | None]:
 
 
 @overload
-def entity_writer(entity_type: type[E]) -> Writer[E]:
+def entity_writer(entity_type: type[E], nullable: Literal[False] = ...) -> Writer[E]:
     ...
 
 

--- a/src/kio/serial/_shared.py
+++ b/src/kio/serial/_shared.py
@@ -1,0 +1,8 @@
+import enum
+
+from kio.static.primitive import i8
+
+
+class NullableEntityMarker(enum.Enum):
+    null = i8(-1)
+    not_null = i8(1)

--- a/src/kio/static/protocol.py
+++ b/src/kio/static/protocol.py
@@ -1,16 +1,9 @@
-from typing import TYPE_CHECKING
 from typing import ClassVar
 from typing import Protocol
 
+from kio._utils import DataclassInstance
+
 from .primitive import i16
-
-if TYPE_CHECKING:
-    from _typeshed import DataclassInstance
-else:
-
-    class DataclassInstance(Protocol):
-        ...
-
 
 __all__ = ("ApiMessage", "Entity", "Payload")
 

--- a/tests/generated/test_consumer_group_heartbeat_v0_response.py
+++ b/tests/generated/test_consumer_group_heartbeat_v0_response.py
@@ -14,6 +14,7 @@ from kio.schema.consumer_group_heartbeat.v0.response import (
 from kio.schema.consumer_group_heartbeat.v0.response import TopicPartitions
 from kio.serial import entity_reader
 from kio.serial import entity_writer
+from tests.conftest import JavaTester
 from tests.conftest import setup_buffer
 
 read_topic_partitions: Final = entity_reader(TopicPartitions)
@@ -63,3 +64,11 @@ def test_consumer_group_heartbeat_response_roundtrip(
         buffer.seek(0)
         result = read_consumer_group_heartbeat_response(buffer)
     assert instance == result
+
+
+@pytest.mark.java
+@given(instance=from_type(ConsumerGroupHeartbeatResponse))
+def test_consumer_group_heartbeat_response_java(
+    instance: ConsumerGroupHeartbeatResponse, java_tester: JavaTester
+) -> None:
+    java_tester.test(instance)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -84,7 +84,7 @@ def write_request_header(
     else:
         raise NotImplementedError(f"Unknown request header schema: {header_schema}")
 
-    entity_writer(header_schema)(buffer, header)  # type: ignore[type-var]
+    entity_writer(header_schema)(buffer, header)  # type: ignore[arg-type]
 
 
 async def send(


### PR DESCRIPTION
This commit implements support for the nullable entity field introduced in `ConsumerGroupHeartbeatResponse.assignment`. This kind of field was formalized upstream in KIP-893 but is not mentioned in any official documentation of the protocol.

The KIP also mentions tagged fields. I left this out as I don't understand why another mechanism for omiting a tagged field value is needed, and AFAIK no entity uses this yet.

Partially addresses #100.