### PR TITLE
chore: Configure codecov upload token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,8 @@ jobs:
           file: coverage.xml
           fail_ci_if_error: true
           name: codecov-py${{ matrix.python-version }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   roundtrip-test:
     name: Roundtrip tests


### PR DESCRIPTION
This is to address seeing lots of failures on uploading coverage reports. Apparently, when not using the token, access to the Github API is hitting rate limits.