### PR TITLE
fix: Bump editorconfig-checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-    rev: "2.7.2"
+    rev: "2.7.3"
     hooks:
       - id: editorconfig-checker
         alias: ec


### PR DESCRIPTION
This was causing spurious failures in CI, see issue: https://github.com/editorconfig-checker/editorconfig-checker.python/issues/28