### PR TITLE
fix: Address flaky integration test

### DIFF
--- a/docs/pages/usage.rst
+++ b/docs/pages/usage.rst
@@ -58,8 +58,9 @@ to Apache Kafka®, and receive and parse the response into a full entity.
             await stream_writer.drain()
 
             # Read response into a temporary buffer.
-            response_length = read_int32(stream_reader)
-            response_buffer = io.BytesIO(await stream_reader.read(response_length))
+            response_length_bytes = await stream.readexactly(4)
+            response_length = read_int32(io.BytesIO(response_length_bytes))
+            response_buffer = io.BytesIO(await stream_reader.readexactly(response_length))
 
         # Parse header and payload from response buffer.
         response_header = read_header(response_buffer)


### PR DESCRIPTION
Trying to figure this one out, I read up again on the [documentation] of `StreamWriter.read()` and took extra note of this passage.

[documentation]: https://docs.python.org/3/library/asyncio-stream.html#asyncio.StreamReader.read

> [...] return at most n available bytes as soon as at least 1 byte is
> available in the internal buffer.

After switching to use `.readexactly()` instead, the error systematically stops occurring.