### PR TITLE
feature: Implement dynamic schema entity imports

### DIFF
--- a/codegen/__main__.py
+++ b/codegen/__main__.py
@@ -1,6 +1,8 @@
+from . import generate_index
 from . import generate_schema
 from . import generate_tests
 
 if __name__ == "__main__":
     generate_schema.main()
     generate_tests.main()
+    generate_index.main()

--- a/codegen/generate_index.py
+++ b/codegen/generate_index.py
@@ -1,0 +1,160 @@
+# ruff: noqa: T201
+
+import sys
+
+from collections import defaultdict
+from collections.abc import Iterator
+from collections.abc import Mapping
+from functools import partial
+from typing import Final
+from typing import NamedTuple
+from typing import TypeAlias
+
+from kio.static.constants import EntityType
+from kio.static.protocol import Entity
+
+from .introspect_schema import base_dir
+from .introspect_schema import get_message_entities
+
+target_path: Final = base_dir / "src/kio/schema/index.py"
+prefix: Final = "kio.schema."
+indent: Final = "    "
+
+module_setup: Final = """\
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
+from typing import Literal
+from typing import TypeAlias
+
+from kio.static.constants import EntityType
+
+__all__ = (
+    "api_key_map",
+    "schema_name_map",
+    "PayloadEntityType",
+    "LoadableEntityType",
+)
+
+PayloadEntityType: TypeAlias = Literal[EntityType.response, EntityType.request]
+LoadableEntityType: TypeAlias = (
+    Literal[EntityType.header, EntityType.data] | PayloadEntityType
+)
+TypeMap: TypeAlias = Mapping[LoadableEntityType, str]
+VersionMap: TypeAlias = Mapping[int, TypeMap]
+SchemaNameMap: TypeAlias = Mapping[str, VersionMap]
+APIKeyMap: TypeAlias = Mapping[int, str]
+
+"""
+
+
+class PathParts(NamedTuple):
+    api_name: str
+    version: int
+    entity_type: EntityType
+    entity_name: str
+
+
+def module_path_parts(entity: type[Entity]) -> PathParts:
+    without_prefix = entity.__module__.removeprefix(prefix)
+    parts = without_prefix.split(".")
+    assert parts[-1] == entity.__type__.name
+    return PathParts(
+        api_name=parts[0],
+        version=int(parts[1][1:]),
+        entity_type=entity.__type__,
+        entity_name=entity.__qualname__,
+    )
+
+
+def fqn(parts: PathParts) -> str:
+    return (
+        f"{prefix}"
+        f"{parts.api_name}"
+        f".v{parts.version}"
+        f".{parts.entity_type.name}"
+        f":{parts.entity_name}"
+    )
+
+
+TypeMap: TypeAlias = Mapping[EntityType, str]
+VersionMap: TypeAlias = Mapping[int, TypeMap]
+SchemaNameMap: TypeAlias = Mapping[str, VersionMap]
+APIKeyMap: TypeAlias = Mapping[int, str]
+
+
+def build_index() -> tuple[SchemaNameMap, APIKeyMap]:
+    schema_name_map: defaultdict[str, defaultdict[int, dict[EntityType, str]]] = (
+        defaultdict(partial(defaultdict, dict))
+    )
+    api_key_map = {}
+    for entity, _ in get_message_entities():
+        parts = module_path_parts(entity)
+        schema_name_map[parts.api_name][parts.version][parts.entity_type] = fqn(parts)
+        if (api_key := getattr(entity, "__api_key__", None)) is not None:
+            api_key_map[api_key] = parts.api_name
+    api_key_map = dict(sorted(api_key_map.items()))
+    return schema_name_map, api_key_map
+
+
+def format_schema_name_map(index: SchemaNameMap) -> Iterator[str]:
+    yield "schema_name_map: Final[SchemaNameMap] = MappingProxyType({"
+
+    for schema_name, version_map in index.items():
+        yield f'{indent}"{schema_name}": MappingProxyType({{'
+
+        for version, type_map in version_map.items():
+            yield f"{indent}{indent}{version}: MappingProxyType({{"
+
+            for entity_type, entity_path in type_map.items():
+                yield (
+                    f"{indent}{indent}{indent}EntityType.{entity_type.name}: ("
+                    f'"{entity_path}"),'
+                )
+
+            yield f"{indent}{indent}}}),"
+
+        yield f"{indent}}}),"
+
+    yield "})"
+    yield ""
+
+
+def format_api_key_map(index: APIKeyMap) -> Iterator[str]:
+    yield "api_key_map: Final[APIKeyMap] = MappingProxyType({"
+
+    for api_key, module_name in index.items():
+        yield f'{indent}{api_key}: "{module_name}",'
+
+    yield "})"
+    yield ""
+
+
+def main() -> None:
+    print("Generating index.", file=sys.stderr)
+    print("Introspecting modules ...", file=sys.stderr, flush=True)
+    schema_name_map, api_key_map = build_index()
+
+    # Smoke test
+    assert (
+        schema_name_map["metadata"][11][EntityType.request]
+        == "kio.schema.metadata.v11.request:MetadataRequest"
+    )
+    assert api_key_map[3] == "metadata"
+
+    print("Writing index file ...", file=sys.stderr, flush=True)
+
+    with target_path.open("w") as target:
+        print(module_setup, file=target)
+
+        for line in format_api_key_map(api_key_map):
+            print(line, file=target)
+
+        for line in format_schema_name_map(schema_name_map):
+            print(line, file=target)
+
+    print("Done.", file=sys.stderr, flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/codegen/introspect_schema.py
+++ b/codegen/introspect_schema.py
@@ -1,0 +1,53 @@
+from collections.abc import Iterator
+from importlib import import_module
+from pathlib import Path
+from pkgutil import walk_packages
+from types import ModuleType
+from typing import Final
+
+import kio.schema
+
+from kio.static.constants import EntityType
+from kio.static.protocol import Entity
+
+base_dir: Final = Path(__file__).parent.parent.resolve()
+schema_src_dir: Final = Path(kio.schema.__file__).parent.resolve()
+ignore_modules: Final = frozenset({"index"})
+
+
+def generate_modules(parent: ModuleType) -> Iterator[ModuleType]:
+    for package in walk_packages(parent.__path__):
+        if package.name in ignore_modules:
+            continue
+        module = import_module(f"{parent.__name__}.{package.name}")
+        if package.ispkg:
+            yield from generate_modules(module)
+        else:
+            yield module
+
+
+def get_entities() -> Iterator[tuple[type[Entity], str]]:
+    modules = list(generate_modules(import_module("kio.schema")))
+    for module in modules:
+        items = module.__dict__.copy()
+        # Eliminate non-entity modules, situated directly under `kio.schema`.
+        if sum(1 for c in module.__name__ if c == ".") < 3:
+            continue
+        for key, value in items.items():
+            if key.startswith("__"):
+                continue
+            # Eliminate anything not defined in the module.
+            if getattr(value, "__module__", None) != module.__name__:
+                continue
+            # Eliminate anything that's not a class.
+            if type(value) is not type:
+                continue
+            assert isinstance(module.__file__, str)
+            yield value, module.__file__
+
+
+def get_message_entities() -> Iterator[tuple[type[Entity], str]]:
+    for entity, file_path in get_entities():
+        if entity.__type__ is EntityType.nested:
+            continue
+        yield entity, file_path

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ Documentation sections
   :maxdepth: 1
 
   pages/schema.rst
+  pages/dynamic-index-lookups.rst
   pages/serial.rst
   pages/usage.rst
   pages/goals.rst

--- a/docs/pages/dynamic-index-lookups.rst
+++ b/docs/pages/dynamic-index-lookups.rst
@@ -1,0 +1,21 @@
+Dynamic index lookups
+=====================
+
+For many applications it is useful to be able to dynamically load schema
+entities. For instance, if building an application that inspects the traffic
+between a consumer or producer and a broker, we would like the ability to parse
+arbitrary requests and responses sent between the two.
+
+The Apache Kafka® Protocol has *lots of entities*, and while loading them all at
+import time is definitely sometimes an option, as this is a fairly slow process,
+it is not suitable for all applications.
+
+The kio library provides the following APIs for applications where it's instead
+deemed preferable to dynamically load schema entities.
+
+Schema entity import functions
+------------------------------
+
+.. automodule:: kio.index
+    :members:
+    :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ max-complexity = 10
 [tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "parents"
 
+
 [tool.importlinter]
 root_packages = ["kio", "codegen", "tests"]
 

--- a/src/kio/index.py
+++ b/src/kio/index.py
@@ -1,0 +1,168 @@
+from pkgutil import resolve_name
+from types import ModuleType
+from typing import cast
+
+from .schema.index import LoadableEntityType
+from .schema.index import PayloadEntityType
+from .schema.index import api_key_map
+from .schema.index import schema_name_map
+from .static.constants import EntityType
+from .static.protocol import Entity
+from .static.protocol import RequestPayload
+from .static.protocol import ResponsePayload
+
+
+class KioIndexError(RuntimeError): ...
+
+
+class UnknownAPIKey(KioIndexError): ...
+
+
+class UnknownEntity(KioIndexError): ...
+
+
+def _name_from_key(api_key: int) -> str:
+    """
+    :raises UnknownAPIKey: When the given API key does not map to an API name.
+    """
+    try:
+        return api_key_map[api_key]
+    except KeyError as e:
+        raise UnknownAPIKey(f"Failed mapping the given API key: {api_key!r}") from e
+
+
+def _get_entity_path(name: str, version: int, entity_type: LoadableEntityType) -> str:
+    """
+    :raises UnknownEntity: When the given arguments do not map to a known entity.
+    """
+    try:
+        return schema_name_map[name][version][entity_type]
+    except KeyError:
+        raise UnknownEntity(
+            f"Failed mapping to a an entity path for ({name=!r}, {version=!r}, "
+            f"entity_type={entity_type.name!r})."
+        ) from None
+
+
+def _resolve(path: str) -> object:
+    try:
+        return resolve_name(path)
+    except (ImportError, ValueError, AttributeError) as e:
+        e.add_note("This error stems from a dynamic import in kio.")
+        raise
+
+
+def load_entity_module(
+    name: str,
+    version: int,
+    entity_type: LoadableEntityType,
+) -> ModuleType:
+    """
+    Load a schema module given the schema name, version, and type.
+
+    :raises UnknownEntity: When the given arguments do not map to a known entity.
+
+    >>> load_entity_module("metadata", 12, EntityType.request)
+    <module 'kio.schema.metadata.v12.request' from '.../kio/schema/metadata/v12/request.py'>
+    """
+    entity_path = _get_entity_path(name, version, entity_type)
+    module_path = entity_path.split(":", 1)[0]
+    resolved = _resolve(module_path)
+    assert isinstance(resolved, ModuleType)
+    return resolved
+
+
+def load_payload_module(
+    api_key: int,
+    version: int,
+    entity_type: PayloadEntityType,
+) -> ModuleType:
+    """
+    Load a schema module of an API message payload, given the API key, version,
+    and type.
+
+    :raises UnknownAPIKey: When the given API key does not map to an API name.
+    :raises UnknownEntity: When the given arguments do not map to a known entity.
+
+    >>> load_payload_module(3, 12, EntityType.request)
+    <module 'kio.schema.metadata.v12.request' from '.../kio/schema/metadata/v12/request.py'>
+    """
+    return load_entity_module(_name_from_key(api_key), version, entity_type)
+
+
+def load_entity_schema(
+    name: str,
+    version: int,
+    entity_type: LoadableEntityType,
+) -> type[Entity]:
+    """
+    Load an entity schema module given the schema name, version, and type.
+
+    :raises UnknownEntity: When the given arguments do not map to a known entity.
+
+    >>> load_entity_schema("metadata", 12, EntityType.response)
+    <class 'kio.schema.metadata.v12.response.MetadataResponse'>
+    """
+    resolved = _resolve(_get_entity_path(name, version, entity_type))
+    assert isinstance(resolved, type)
+    return cast(type[Entity], resolved)
+
+
+def load_response_schema(api_key: int, version: int) -> type[ResponsePayload]:
+    """
+    Load a response payload schema entity given its API key, and version.
+
+    :raises UnknownAPIKey: When the given API key does not map to an API name.
+    :raises UnknownEntity: When the given arguments do not map to a known entity.
+
+    >>> load_response_schema(3, 12)
+    <class 'kio.schema.metadata.v12.response.MetadataResponse'>
+    """
+    resolved = load_entity_schema(_name_from_key(api_key), version, EntityType.response)
+    return cast(type[ResponsePayload], resolved)
+
+
+def load_request_schema(api_key: int, version: int) -> type[RequestPayload]:
+    """
+    Load a request payload schema entity given its API key, and version.
+
+    :raises UnknownAPIKey: When the given API key does not map to an API name.
+    :raises UnknownEntity: When the given arguments do not map to a known entity.
+
+    >>> load_request_schema(3, 12)
+    <class 'kio.schema.metadata.v12.request.MetadataRequest'>
+    """
+    resolved = load_entity_schema(_name_from_key(api_key), version, EntityType.request)
+    return cast(type[RequestPayload], resolved)
+
+
+def load_response_from_request(
+    request_type: type[RequestPayload] | RequestPayload,
+) -> type[ResponsePayload]:
+    """
+    Load a response payload schema entity given its corresponding request type.
+
+    :raises UnknownAPIKey: When the given API key does not map to an API name.
+    :raises UnknownEntity: When the given arguments do not map to a known entity.
+
+    >>> from kio.schema.metadata.v12 import MetadataRequest
+    >>> load_response_from_request(MetadataRequest)
+    <class 'kio.schema.metadata.v12.response.MetadataResponse'>
+    """
+    return load_response_schema(request_type.__api_key__, request_type.__version__)
+
+
+def load_request_from_response(
+    response_type: type[ResponsePayload] | ResponsePayload,
+) -> type[RequestPayload]:
+    """
+    Load a request payload schema entity given its corresponding response type.
+
+    :raises UnknownAPIKey: When the given API key does not map to an API name.
+    :raises UnknownEntity: When the given arguments do not map to a known entity.
+
+    >>> from kio.schema.metadata.v12 import MetadataResponse
+    >>> load_request_from_response(MetadataResponse)
+    <class 'kio.schema.metadata.v12.request.MetadataRequest'>
+    """
+    return load_request_schema(response_type.__api_key__, response_type.__version__)

--- a/src/kio/schema/index.py
+++ b/src/kio/schema/index.py
@@ -1,0 +1,3308 @@
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Final
+from typing import Literal
+from typing import TypeAlias
+
+from kio.static.constants import EntityType
+
+__all__ = (
+    "api_key_map",
+    "schema_name_map",
+    "PayloadEntityType",
+    "LoadableEntityType",
+)
+
+PayloadEntityType: TypeAlias = Literal[EntityType.response, EntityType.request]
+LoadableEntityType: TypeAlias = (
+    Literal[EntityType.header, EntityType.data] | PayloadEntityType
+)
+TypeMap: TypeAlias = Mapping[LoadableEntityType, str]
+VersionMap: TypeAlias = Mapping[int, TypeMap]
+SchemaNameMap: TypeAlias = Mapping[str, VersionMap]
+APIKeyMap: TypeAlias = Mapping[int, str]
+
+
+api_key_map: Final[APIKeyMap] = MappingProxyType(
+    {
+        0: "produce",
+        1: "fetch",
+        2: "list_offsets",
+        3: "metadata",
+        4: "leader_and_isr",
+        5: "stop_replica",
+        6: "update_metadata",
+        7: "controlled_shutdown",
+        8: "offset_commit",
+        9: "offset_fetch",
+        10: "find_coordinator",
+        11: "join_group",
+        12: "heartbeat",
+        13: "leave_group",
+        14: "sync_group",
+        15: "describe_groups",
+        16: "list_groups",
+        17: "sasl_handshake",
+        18: "api_versions",
+        19: "create_topics",
+        20: "delete_topics",
+        21: "delete_records",
+        22: "init_producer_id",
+        23: "offset_for_leader_epoch",
+        24: "add_partitions_to_txn",
+        25: "add_offsets_to_txn",
+        26: "end_txn",
+        27: "write_txn_markers",
+        28: "txn_offset_commit",
+        29: "describe_acls",
+        30: "create_acls",
+        31: "delete_acls",
+        32: "describe_configs",
+        33: "alter_configs",
+        34: "alter_replica_log_dirs",
+        35: "describe_log_dirs",
+        36: "sasl_authenticate",
+        37: "create_partitions",
+        38: "create_delegation_token",
+        39: "renew_delegation_token",
+        40: "expire_delegation_token",
+        41: "describe_delegation_token",
+        42: "delete_groups",
+        43: "elect_leaders",
+        44: "incremental_alter_configs",
+        45: "alter_partition_reassignments",
+        46: "list_partition_reassignments",
+        47: "offset_delete",
+        48: "describe_client_quotas",
+        49: "alter_client_quotas",
+        50: "describe_user_scram_credentials",
+        51: "alter_user_scram_credentials",
+        52: "vote",
+        53: "begin_quorum_epoch",
+        54: "end_quorum_epoch",
+        55: "describe_quorum",
+        56: "alter_partition",
+        57: "update_features",
+        58: "envelope",
+        59: "fetch_snapshot",
+        60: "describe_cluster",
+        61: "describe_producers",
+        62: "broker_registration",
+        63: "broker_heartbeat",
+        64: "unregister_broker",
+        65: "describe_transactions",
+        66: "list_transactions",
+        67: "allocate_producer_ids",
+        68: "consumer_group_heartbeat",
+    }
+)
+
+schema_name_map: Final[SchemaNameMap] = MappingProxyType(
+    {
+        "add_offsets_to_txn": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_offsets_to_txn.v0.request:AddOffsetsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_offsets_to_txn.v0.response:AddOffsetsToTxnResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_offsets_to_txn.v1.request:AddOffsetsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_offsets_to_txn.v1.response:AddOffsetsToTxnResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_offsets_to_txn.v2.request:AddOffsetsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_offsets_to_txn.v2.response:AddOffsetsToTxnResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_offsets_to_txn.v3.request:AddOffsetsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_offsets_to_txn.v3.response:AddOffsetsToTxnResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "add_partitions_to_txn": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_partitions_to_txn.v0.request:AddPartitionsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_partitions_to_txn.v0.response:AddPartitionsToTxnResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_partitions_to_txn.v1.request:AddPartitionsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_partitions_to_txn.v1.response:AddPartitionsToTxnResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_partitions_to_txn.v2.request:AddPartitionsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_partitions_to_txn.v2.response:AddPartitionsToTxnResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_partitions_to_txn.v3.request:AddPartitionsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_partitions_to_txn.v3.response:AddPartitionsToTxnResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.add_partitions_to_txn.v4.request:AddPartitionsToTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.add_partitions_to_txn.v4.response:AddPartitionsToTxnResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "allocate_producer_ids": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.allocate_producer_ids.v0.request:AllocateProducerIdsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.allocate_producer_ids.v0.response:AllocateProducerIdsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "alter_client_quotas": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_client_quotas.v0.request:AlterClientQuotasRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_client_quotas.v0.response:AlterClientQuotasResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_client_quotas.v1.request:AlterClientQuotasRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_client_quotas.v1.response:AlterClientQuotasResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "alter_configs": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_configs.v0.request:AlterConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_configs.v0.response:AlterConfigsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_configs.v1.request:AlterConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_configs.v1.response:AlterConfigsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_configs.v2.request:AlterConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_configs.v2.response:AlterConfigsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "alter_partition": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_partition.v0.request:AlterPartitionRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_partition.v0.response:AlterPartitionResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_partition.v1.request:AlterPartitionRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_partition.v1.response:AlterPartitionResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_partition.v2.request:AlterPartitionRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_partition.v2.response:AlterPartitionResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_partition.v3.request:AlterPartitionRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_partition.v3.response:AlterPartitionResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "alter_partition_reassignments": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_partition_reassignments.v0.request:AlterPartitionReassignmentsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_partition_reassignments.v0.response:AlterPartitionReassignmentsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "alter_replica_log_dirs": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_replica_log_dirs.v0.request:AlterReplicaLogDirsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_replica_log_dirs.v0.response:AlterReplicaLogDirsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_replica_log_dirs.v1.request:AlterReplicaLogDirsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_replica_log_dirs.v1.response:AlterReplicaLogDirsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_replica_log_dirs.v2.request:AlterReplicaLogDirsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_replica_log_dirs.v2.response:AlterReplicaLogDirsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "alter_user_scram_credentials": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.alter_user_scram_credentials.v0.request:AlterUserScramCredentialsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.alter_user_scram_credentials.v0.response:AlterUserScramCredentialsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "api_versions": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.api_versions.v0.request:ApiVersionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.api_versions.v0.response:ApiVersionsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.api_versions.v1.request:ApiVersionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.api_versions.v1.response:ApiVersionsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.api_versions.v2.request:ApiVersionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.api_versions.v2.response:ApiVersionsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.api_versions.v3.request:ApiVersionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.api_versions.v3.response:ApiVersionsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "begin_quorum_epoch": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.begin_quorum_epoch.v0.request:BeginQuorumEpochRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.begin_quorum_epoch.v0.response:BeginQuorumEpochResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "broker_heartbeat": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.broker_heartbeat.v0.request:BrokerHeartbeatRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.broker_heartbeat.v0.response:BrokerHeartbeatResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "broker_registration": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.broker_registration.v0.request:BrokerRegistrationRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.broker_registration.v0.response:BrokerRegistrationResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.broker_registration.v1.request:BrokerRegistrationRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.broker_registration.v1.response:BrokerRegistrationResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "consumer_group_heartbeat": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.consumer_group_heartbeat.v0.request:ConsumerGroupHeartbeatRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.consumer_group_heartbeat.v0.response:ConsumerGroupHeartbeatResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "consumer_protocol_assignment": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.consumer_protocol_assignment.v0.data:ConsumerProtocolAssignment"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.consumer_protocol_assignment.v1.data:ConsumerProtocolAssignment"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.consumer_protocol_assignment.v2.data:ConsumerProtocolAssignment"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.consumer_protocol_assignment.v3.data:ConsumerProtocolAssignment"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "consumer_protocol_subscription": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.consumer_protocol_subscription.v0.data:ConsumerProtocolSubscription"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.consumer_protocol_subscription.v1.data:ConsumerProtocolSubscription"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.consumer_protocol_subscription.v2.data:ConsumerProtocolSubscription"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.consumer_protocol_subscription.v3.data:ConsumerProtocolSubscription"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "controlled_shutdown": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.controlled_shutdown.v0.request:ControlledShutdownRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.controlled_shutdown.v0.response:ControlledShutdownResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.controlled_shutdown.v1.request:ControlledShutdownRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.controlled_shutdown.v1.response:ControlledShutdownResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.controlled_shutdown.v2.request:ControlledShutdownRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.controlled_shutdown.v2.response:ControlledShutdownResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.controlled_shutdown.v3.request:ControlledShutdownRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.controlled_shutdown.v3.response:ControlledShutdownResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "create_acls": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_acls.v0.request:CreateAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_acls.v0.response:CreateAclsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_acls.v1.request:CreateAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_acls.v1.response:CreateAclsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_acls.v2.request:CreateAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_acls.v2.response:CreateAclsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_acls.v3.request:CreateAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_acls.v3.response:CreateAclsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "create_delegation_token": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_delegation_token.v0.request:CreateDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_delegation_token.v0.response:CreateDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_delegation_token.v1.request:CreateDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_delegation_token.v1.response:CreateDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_delegation_token.v2.request:CreateDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_delegation_token.v2.response:CreateDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_delegation_token.v3.request:CreateDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_delegation_token.v3.response:CreateDelegationTokenResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "create_partitions": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_partitions.v0.request:CreatePartitionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_partitions.v0.response:CreatePartitionsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_partitions.v1.request:CreatePartitionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_partitions.v1.response:CreatePartitionsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_partitions.v2.request:CreatePartitionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_partitions.v2.response:CreatePartitionsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_partitions.v3.request:CreatePartitionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_partitions.v3.response:CreatePartitionsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "create_topics": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_topics.v0.request:CreateTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_topics.v0.response:CreateTopicsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_topics.v1.request:CreateTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_topics.v1.response:CreateTopicsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_topics.v2.request:CreateTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_topics.v2.response:CreateTopicsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_topics.v3.request:CreateTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_topics.v3.response:CreateTopicsResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_topics.v4.request:CreateTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_topics.v4.response:CreateTopicsResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_topics.v5.request:CreateTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_topics.v5.response:CreateTopicsResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_topics.v6.request:CreateTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_topics.v6.response:CreateTopicsResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.create_topics.v7.request:CreateTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.create_topics.v7.response:CreateTopicsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "default_principal_data": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.default_principal_data.v0.data:DefaultPrincipalData"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "delete_acls": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_acls.v0.request:DeleteAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_acls.v0.response:DeleteAclsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_acls.v1.request:DeleteAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_acls.v1.response:DeleteAclsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_acls.v2.request:DeleteAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_acls.v2.response:DeleteAclsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_acls.v3.request:DeleteAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_acls.v3.response:DeleteAclsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "delete_groups": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_groups.v0.request:DeleteGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_groups.v0.response:DeleteGroupsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_groups.v1.request:DeleteGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_groups.v1.response:DeleteGroupsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_groups.v2.request:DeleteGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_groups.v2.response:DeleteGroupsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "delete_records": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_records.v0.request:DeleteRecordsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_records.v0.response:DeleteRecordsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_records.v1.request:DeleteRecordsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_records.v1.response:DeleteRecordsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_records.v2.request:DeleteRecordsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_records.v2.response:DeleteRecordsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "delete_topics": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_topics.v0.request:DeleteTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_topics.v0.response:DeleteTopicsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_topics.v1.request:DeleteTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_topics.v1.response:DeleteTopicsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_topics.v2.request:DeleteTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_topics.v2.response:DeleteTopicsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_topics.v3.request:DeleteTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_topics.v3.response:DeleteTopicsResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_topics.v4.request:DeleteTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_topics.v4.response:DeleteTopicsResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_topics.v5.request:DeleteTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_topics.v5.response:DeleteTopicsResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.delete_topics.v6.request:DeleteTopicsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.delete_topics.v6.response:DeleteTopicsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_acls": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_acls.v0.request:DescribeAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_acls.v0.response:DescribeAclsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_acls.v1.request:DescribeAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_acls.v1.response:DescribeAclsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_acls.v2.request:DescribeAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_acls.v2.response:DescribeAclsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_acls.v3.request:DescribeAclsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_acls.v3.response:DescribeAclsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_client_quotas": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_client_quotas.v0.request:DescribeClientQuotasRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_client_quotas.v0.response:DescribeClientQuotasResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_client_quotas.v1.request:DescribeClientQuotasRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_client_quotas.v1.response:DescribeClientQuotasResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_cluster": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_cluster.v0.request:DescribeClusterRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_cluster.v0.response:DescribeClusterResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_configs": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_configs.v0.request:DescribeConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_configs.v0.response:DescribeConfigsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_configs.v1.request:DescribeConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_configs.v1.response:DescribeConfigsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_configs.v2.request:DescribeConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_configs.v2.response:DescribeConfigsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_configs.v3.request:DescribeConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_configs.v3.response:DescribeConfigsResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_configs.v4.request:DescribeConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_configs.v4.response:DescribeConfigsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_delegation_token": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_delegation_token.v0.request:DescribeDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_delegation_token.v0.response:DescribeDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_delegation_token.v1.request:DescribeDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_delegation_token.v1.response:DescribeDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_delegation_token.v2.request:DescribeDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_delegation_token.v2.response:DescribeDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_delegation_token.v3.request:DescribeDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_delegation_token.v3.response:DescribeDelegationTokenResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_groups": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_groups.v0.request:DescribeGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_groups.v0.response:DescribeGroupsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_groups.v1.request:DescribeGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_groups.v1.response:DescribeGroupsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_groups.v2.request:DescribeGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_groups.v2.response:DescribeGroupsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_groups.v3.request:DescribeGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_groups.v3.response:DescribeGroupsResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_groups.v4.request:DescribeGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_groups.v4.response:DescribeGroupsResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_groups.v5.request:DescribeGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_groups.v5.response:DescribeGroupsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_log_dirs": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_log_dirs.v0.request:DescribeLogDirsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_log_dirs.v0.response:DescribeLogDirsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_log_dirs.v1.request:DescribeLogDirsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_log_dirs.v1.response:DescribeLogDirsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_log_dirs.v2.request:DescribeLogDirsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_log_dirs.v2.response:DescribeLogDirsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_log_dirs.v3.request:DescribeLogDirsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_log_dirs.v3.response:DescribeLogDirsResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_log_dirs.v4.request:DescribeLogDirsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_log_dirs.v4.response:DescribeLogDirsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_producers": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_producers.v0.request:DescribeProducersRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_producers.v0.response:DescribeProducersResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_quorum": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_quorum.v0.request:DescribeQuorumRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_quorum.v0.response:DescribeQuorumResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_quorum.v1.request:DescribeQuorumRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_quorum.v1.response:DescribeQuorumResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_transactions": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_transactions.v0.request:DescribeTransactionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_transactions.v0.response:DescribeTransactionsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "describe_user_scram_credentials": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.describe_user_scram_credentials.v0.request:DescribeUserScramCredentialsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.describe_user_scram_credentials.v0.response:DescribeUserScramCredentialsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "elect_leaders": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.elect_leaders.v0.request:ElectLeadersRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.elect_leaders.v0.response:ElectLeadersResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.elect_leaders.v1.request:ElectLeadersRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.elect_leaders.v1.response:ElectLeadersResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.elect_leaders.v2.request:ElectLeadersRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.elect_leaders.v2.response:ElectLeadersResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "end_quorum_epoch": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.end_quorum_epoch.v0.request:EndQuorumEpochRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.end_quorum_epoch.v0.response:EndQuorumEpochResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "end_txn": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.end_txn.v0.request:EndTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.end_txn.v0.response:EndTxnResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.end_txn.v1.request:EndTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.end_txn.v1.response:EndTxnResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.end_txn.v2.request:EndTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.end_txn.v2.response:EndTxnResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.end_txn.v3.request:EndTxnRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.end_txn.v3.response:EndTxnResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "envelope": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.envelope.v0.request:EnvelopeRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.envelope.v0.response:EnvelopeResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "expire_delegation_token": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.expire_delegation_token.v0.request:ExpireDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.expire_delegation_token.v0.response:ExpireDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.expire_delegation_token.v1.request:ExpireDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.expire_delegation_token.v1.response:ExpireDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.expire_delegation_token.v2.request:ExpireDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.expire_delegation_token.v2.response:ExpireDelegationTokenResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "fetch": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v0.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v0.response:FetchResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v1.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v1.response:FetchResponse"
+                        ),
+                    }
+                ),
+                10: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v10.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v10.response:FetchResponse"
+                        ),
+                    }
+                ),
+                11: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v11.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v11.response:FetchResponse"
+                        ),
+                    }
+                ),
+                12: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v12.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v12.response:FetchResponse"
+                        ),
+                    }
+                ),
+                13: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v13.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v13.response:FetchResponse"
+                        ),
+                    }
+                ),
+                14: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v14.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v14.response:FetchResponse"
+                        ),
+                    }
+                ),
+                15: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v15.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v15.response:FetchResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v2.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v2.response:FetchResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v3.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v3.response:FetchResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v4.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v4.response:FetchResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v5.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v5.response:FetchResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v6.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v6.response:FetchResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v7.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v7.response:FetchResponse"
+                        ),
+                    }
+                ),
+                8: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v8.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v8.response:FetchResponse"
+                        ),
+                    }
+                ),
+                9: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch.v9.request:FetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch.v9.response:FetchResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "fetch_snapshot": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.fetch_snapshot.v0.request:FetchSnapshotRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.fetch_snapshot.v0.response:FetchSnapshotResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "find_coordinator": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.find_coordinator.v0.request:FindCoordinatorRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.find_coordinator.v0.response:FindCoordinatorResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.find_coordinator.v1.request:FindCoordinatorRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.find_coordinator.v1.response:FindCoordinatorResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.find_coordinator.v2.request:FindCoordinatorRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.find_coordinator.v2.response:FindCoordinatorResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.find_coordinator.v3.request:FindCoordinatorRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.find_coordinator.v3.response:FindCoordinatorResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.find_coordinator.v4.request:FindCoordinatorRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.find_coordinator.v4.response:FindCoordinatorResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "heartbeat": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.heartbeat.v0.request:HeartbeatRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.heartbeat.v0.response:HeartbeatResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.heartbeat.v1.request:HeartbeatRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.heartbeat.v1.response:HeartbeatResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.heartbeat.v2.request:HeartbeatRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.heartbeat.v2.response:HeartbeatResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.heartbeat.v3.request:HeartbeatRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.heartbeat.v3.response:HeartbeatResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.heartbeat.v4.request:HeartbeatRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.heartbeat.v4.response:HeartbeatResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "incremental_alter_configs": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.incremental_alter_configs.v0.request:IncrementalAlterConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.incremental_alter_configs.v0.response:IncrementalAlterConfigsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.incremental_alter_configs.v1.request:IncrementalAlterConfigsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.incremental_alter_configs.v1.response:IncrementalAlterConfigsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "init_producer_id": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.init_producer_id.v0.request:InitProducerIdRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.init_producer_id.v0.response:InitProducerIdResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.init_producer_id.v1.request:InitProducerIdRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.init_producer_id.v1.response:InitProducerIdResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.init_producer_id.v2.request:InitProducerIdRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.init_producer_id.v2.response:InitProducerIdResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.init_producer_id.v3.request:InitProducerIdRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.init_producer_id.v3.response:InitProducerIdResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.init_producer_id.v4.request:InitProducerIdRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.init_producer_id.v4.response:InitProducerIdResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "join_group": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v0.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v0.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v1.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v1.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v2.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v2.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v3.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v3.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v4.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v4.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v5.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v5.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v6.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v6.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v7.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v7.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                8: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v8.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v8.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+                9: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.join_group.v9.request:JoinGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.join_group.v9.response:JoinGroupResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "leader_and_isr": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leader_and_isr.v0.request:LeaderAndIsrRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leader_and_isr.v0.response:LeaderAndIsrResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leader_and_isr.v1.request:LeaderAndIsrRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leader_and_isr.v1.response:LeaderAndIsrResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leader_and_isr.v2.request:LeaderAndIsrRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leader_and_isr.v2.response:LeaderAndIsrResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leader_and_isr.v3.request:LeaderAndIsrRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leader_and_isr.v3.response:LeaderAndIsrResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leader_and_isr.v4.request:LeaderAndIsrRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leader_and_isr.v4.response:LeaderAndIsrResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leader_and_isr.v5.request:LeaderAndIsrRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leader_and_isr.v5.response:LeaderAndIsrResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leader_and_isr.v6.request:LeaderAndIsrRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leader_and_isr.v6.response:LeaderAndIsrResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leader_and_isr.v7.request:LeaderAndIsrRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leader_and_isr.v7.response:LeaderAndIsrResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "leader_change_message": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.leader_change_message.v0.data:LeaderChangeMessage"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "leave_group": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leave_group.v0.request:LeaveGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leave_group.v0.response:LeaveGroupResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leave_group.v1.request:LeaveGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leave_group.v1.response:LeaveGroupResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leave_group.v2.request:LeaveGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leave_group.v2.response:LeaveGroupResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leave_group.v3.request:LeaveGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leave_group.v3.response:LeaveGroupResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leave_group.v4.request:LeaveGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leave_group.v4.response:LeaveGroupResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.leave_group.v5.request:LeaveGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.leave_group.v5.response:LeaveGroupResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "list_groups": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_groups.v0.request:ListGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_groups.v0.response:ListGroupsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_groups.v1.request:ListGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_groups.v1.response:ListGroupsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_groups.v2.request:ListGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_groups.v2.response:ListGroupsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_groups.v3.request:ListGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_groups.v3.response:ListGroupsResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_groups.v4.request:ListGroupsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_groups.v4.response:ListGroupsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "list_offsets": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v0.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v0.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v1.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v1.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v2.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v2.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v3.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v3.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v4.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v4.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v5.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v5.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v6.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v6.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v7.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v7.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+                8: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_offsets.v8.request:ListOffsetsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_offsets.v8.response:ListOffsetsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "list_partition_reassignments": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_partition_reassignments.v0.request:ListPartitionReassignmentsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_partition_reassignments.v0.response:ListPartitionReassignmentsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "list_transactions": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.list_transactions.v0.request:ListTransactionsRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.list_transactions.v0.response:ListTransactionsResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "metadata": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v0.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v0.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v1.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v1.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                10: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v10.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v10.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                11: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v11.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v11.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                12: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v12.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v12.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v2.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v2.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v3.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v3.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v4.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v4.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v5.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v5.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v6.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v6.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v7.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v7.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                8: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v8.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v8.response:MetadataResponse"
+                        ),
+                    }
+                ),
+                9: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.metadata.v9.request:MetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.metadata.v9.response:MetadataResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "offset_commit": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v0.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v0.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v1.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v1.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v2.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v2.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v3.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v3.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v4.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v4.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v5.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v5.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v6.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v6.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v7.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v7.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                8: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v8.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v8.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+                9: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_commit.v9.request:OffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_commit.v9.response:OffsetCommitResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "offset_delete": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_delete.v0.request:OffsetDeleteRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_delete.v0.response:OffsetDeleteResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "offset_fetch": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v0.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v0.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v1.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v1.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v2.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v2.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v3.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v3.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v4.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v4.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v5.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v5.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v6.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v6.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v7.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v7.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+                8: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_fetch.v8.request:OffsetFetchRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_fetch.v8.response:OffsetFetchResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "offset_for_leader_epoch": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_for_leader_epoch.v0.request:OffsetForLeaderEpochRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_for_leader_epoch.v0.response:OffsetForLeaderEpochResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_for_leader_epoch.v1.request:OffsetForLeaderEpochRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_for_leader_epoch.v1.response:OffsetForLeaderEpochResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_for_leader_epoch.v2.request:OffsetForLeaderEpochRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_for_leader_epoch.v2.response:OffsetForLeaderEpochResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_for_leader_epoch.v3.request:OffsetForLeaderEpochRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_for_leader_epoch.v3.response:OffsetForLeaderEpochResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.offset_for_leader_epoch.v4.request:OffsetForLeaderEpochRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.offset_for_leader_epoch.v4.response:OffsetForLeaderEpochResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "produce": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v0.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v0.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v1.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v1.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v2.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v2.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v3.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v3.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v4.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v4.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v5.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v5.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v6.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v6.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v7.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v7.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                8: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v8.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v8.response:ProduceResponse"
+                        ),
+                    }
+                ),
+                9: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.produce.v9.request:ProduceRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.produce.v9.response:ProduceResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "renew_delegation_token": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.renew_delegation_token.v0.request:RenewDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.renew_delegation_token.v0.response:RenewDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.renew_delegation_token.v1.request:RenewDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.renew_delegation_token.v1.response:RenewDelegationTokenResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.renew_delegation_token.v2.request:RenewDelegationTokenRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.renew_delegation_token.v2.response:RenewDelegationTokenResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "request_header": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.header: (
+                            "kio.schema.request_header.v0.header:RequestHeader"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.header: (
+                            "kio.schema.request_header.v1.header:RequestHeader"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.header: (
+                            "kio.schema.request_header.v2.header:RequestHeader"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "response_header": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.header: (
+                            "kio.schema.response_header.v0.header:ResponseHeader"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.header: (
+                            "kio.schema.response_header.v1.header:ResponseHeader"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "sasl_authenticate": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sasl_authenticate.v0.request:SaslAuthenticateRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sasl_authenticate.v0.response:SaslAuthenticateResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sasl_authenticate.v1.request:SaslAuthenticateRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sasl_authenticate.v1.response:SaslAuthenticateResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sasl_authenticate.v2.request:SaslAuthenticateRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sasl_authenticate.v2.response:SaslAuthenticateResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "sasl_handshake": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sasl_handshake.v0.request:SaslHandshakeRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sasl_handshake.v0.response:SaslHandshakeResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sasl_handshake.v1.request:SaslHandshakeRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sasl_handshake.v1.response:SaslHandshakeResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "snapshot_footer_record": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.snapshot_footer_record.v0.data:SnapshotFooterRecord"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "snapshot_header_record": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.data: (
+                            "kio.schema.snapshot_header_record.v0.data:SnapshotHeaderRecord"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "stop_replica": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.stop_replica.v0.request:StopReplicaRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.stop_replica.v0.response:StopReplicaResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.stop_replica.v1.request:StopReplicaRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.stop_replica.v1.response:StopReplicaResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.stop_replica.v2.request:StopReplicaRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.stop_replica.v2.response:StopReplicaResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.stop_replica.v3.request:StopReplicaRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.stop_replica.v3.response:StopReplicaResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.stop_replica.v4.request:StopReplicaRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.stop_replica.v4.response:StopReplicaResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "sync_group": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sync_group.v0.request:SyncGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sync_group.v0.response:SyncGroupResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sync_group.v1.request:SyncGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sync_group.v1.response:SyncGroupResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sync_group.v2.request:SyncGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sync_group.v2.response:SyncGroupResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sync_group.v3.request:SyncGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sync_group.v3.response:SyncGroupResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sync_group.v4.request:SyncGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sync_group.v4.response:SyncGroupResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.sync_group.v5.request:SyncGroupRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.sync_group.v5.response:SyncGroupResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "txn_offset_commit": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.txn_offset_commit.v0.request:TxnOffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.txn_offset_commit.v0.response:TxnOffsetCommitResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.txn_offset_commit.v1.request:TxnOffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.txn_offset_commit.v1.response:TxnOffsetCommitResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.txn_offset_commit.v2.request:TxnOffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.txn_offset_commit.v2.response:TxnOffsetCommitResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.txn_offset_commit.v3.request:TxnOffsetCommitRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.txn_offset_commit.v3.response:TxnOffsetCommitResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "unregister_broker": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.unregister_broker.v0.request:UnregisterBrokerRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.unregister_broker.v0.response:UnregisterBrokerResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "update_features": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_features.v0.request:UpdateFeaturesRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_features.v0.response:UpdateFeaturesResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_features.v1.request:UpdateFeaturesRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_features.v1.response:UpdateFeaturesResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "update_metadata": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v0.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v0.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v1.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v1.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+                2: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v2.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v2.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+                3: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v3.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v3.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+                4: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v4.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v4.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+                5: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v5.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v5.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+                6: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v6.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v6.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+                7: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v7.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v7.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+                8: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.update_metadata.v8.request:UpdateMetadataRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.update_metadata.v8.response:UpdateMetadataResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "vote": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: ("kio.schema.vote.v0.request:VoteRequest"),
+                        EntityType.response: (
+                            "kio.schema.vote.v0.response:VoteResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+        "write_txn_markers": MappingProxyType(
+            {
+                0: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.write_txn_markers.v0.request:WriteTxnMarkersRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.write_txn_markers.v0.response:WriteTxnMarkersResponse"
+                        ),
+                    }
+                ),
+                1: MappingProxyType(
+                    {
+                        EntityType.request: (
+                            "kio.schema.write_txn_markers.v1.request:WriteTxnMarkersRequest"
+                        ),
+                        EntityType.response: (
+                            "kio.schema.write_txn_markers.v1.response:WriteTxnMarkersResponse"
+                        ),
+                    }
+                ),
+            }
+        ),
+    }
+)

--- a/tests/schema/test_index.py
+++ b/tests/schema/test_index.py
@@ -1,0 +1,18 @@
+from kio.schema.index import api_key_map
+from kio.schema.index import schema_name_map
+from kio.static.constants import EntityType
+
+
+def test_smoke_test_api_key_map() -> None:
+    assert api_key_map[3] == "metadata"
+
+
+def test_smoke_test_schema_name_map() -> None:
+    assert (
+        schema_name_map["metadata"][12][EntityType.request]
+        == "kio.schema.metadata.v12.request:MetadataRequest"
+    )
+    assert (
+        schema_name_map["metadata"][12][EntityType.response]
+        == "kio.schema.metadata.v12.response:MetadataResponse"
+    )

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,119 @@
+from unittest import mock
+
+import pytest
+
+import kio.schema.metadata.v12.request
+import kio.schema.metadata.v12.response
+
+from kio.index import UnknownAPIKey
+from kio.index import UnknownEntity
+from kio.index import _get_entity_path
+from kio.index import _name_from_key
+from kio.index import _resolve
+from kio.index import load_entity_module
+from kio.index import load_entity_schema
+from kio.index import load_payload_module
+from kio.index import load_request_from_response
+from kio.index import load_request_schema
+from kio.index import load_response_from_request
+from kio.index import load_response_schema
+from kio.static.constants import EntityType
+
+
+class TestNameFromKey:
+    def test_returns_associated_module_name(self) -> None:
+        assert _name_from_key(3) == "metadata"
+
+    def test_raises_unknown_api_key_for_invalid_key(self) -> None:
+        with pytest.raises(UnknownAPIKey):
+            _name_from_key(-1)
+
+
+class TestGetEntityPath:
+    def test_returns_correct_entity_path(self) -> None:
+        assert (
+            _get_entity_path("metadata", 12, EntityType.request)
+            == "kio.schema.metadata.v12.request:MetadataRequest"
+        )
+
+    def test_raises_unknown_entity_path_for_missing_schema_name(self) -> None:
+        with pytest.raises(UnknownEntity):
+            _get_entity_path("_metadata", 12, EntityType.request)
+
+    def test_raises_unknown_entity_path_for_missing_version(self) -> None:
+        with pytest.raises(UnknownEntity):
+            _get_entity_path("metadata", 999_999, EntityType.request)
+
+    def test_raises_unknown_entity_path_for_missing_entity_type(self) -> None:
+        with pytest.raises(UnknownEntity):
+            _get_entity_path("metadata", 12, EntityType.data)
+
+
+class TestResolve:
+    def test_can_resolve_existing_path(self) -> None:
+        import kio.schema.metadata.v12.request
+
+        assert (
+            _resolve("kio.schema.metadata.v12.request:MetadataRequest")
+            is kio.schema.metadata.v12.MetadataRequest
+        )
+
+    @pytest.mark.parametrize(
+        "error",
+        (ImportError, ValueError, AttributeError),
+    )
+    def test_reraises_import_errors_with_note(
+        self,
+        error: type[Exception],
+    ) -> None:
+        with (
+            mock.patch("kio.index.resolve_name", side_effect=error),
+            pytest.raises(error) as exc_info,
+        ):
+            _resolve("missing:missing")
+
+        assert (
+            "This error stems from a dynamic import in kio." in exc_info.value.__notes__
+        )
+
+
+class TestLoadEntityModule:
+    def test_can_load_entity_module(self) -> None:
+        loaded = load_entity_module("metadata", 12, EntityType.request)
+        assert loaded is kio.schema.metadata.v12.request
+
+
+class TestLoadPayloadModule:
+    def test_can_load_payload_module(self) -> None:
+        loaded = load_payload_module(3, 12, EntityType.request)
+        assert loaded is kio.schema.metadata.v12.request
+
+
+class TestLoadEntitySchema:
+    def test_can_load_entity_schema(self) -> None:
+        loaded = load_entity_schema("metadata", 12, EntityType.request)
+        assert loaded is kio.schema.metadata.v12.MetadataRequest
+
+
+class TestLoadResponseSchema:
+    def test_can_load_response_schema(self) -> None:
+        loaded = load_response_schema(3, 12)
+        assert loaded is kio.schema.metadata.v12.MetadataResponse
+
+
+class TestLoadRequestSchema:
+    def test_can_load_request_schema(self) -> None:
+        loaded = load_request_schema(3, 12)
+        assert loaded is kio.schema.metadata.v12.MetadataRequest
+
+
+class TestLoadResponseFromRequest:
+    def test_can_load_response_from_request(self) -> None:
+        loaded = load_response_from_request(kio.schema.metadata.v12.MetadataRequest)
+        assert loaded is kio.schema.metadata.v12.MetadataResponse
+
+
+class TestLoadRequestFromResponse:
+    def test_can_load_request_from_response(self) -> None:
+        loaded = load_request_from_response(kio.schema.metadata.v12.MetadataResponse)
+        assert loaded is kio.schema.metadata.v12.MetadataRequest


### PR DESCRIPTION
This commit implements a set of helper functions to dynamically import entities from the schema. They allow:

- Importing requests given their response type, and vice versa.
- Importing payload entities given their API key and type.
- Importing any schema entitiy given its schema name and type.

This is backed by an index that maps (schema name, version, entity type) to an importable path name. The index is pre-generated together with the rest of the schema, to limit impact on runtime code as much as possible.

Supersedes #150, fixes #115.