### PR TITLE
chore: Put docs link in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ all = [
 
 [project.urls]
 "Source Repository" = "https://github.com/Aiven-Open/kio"
+"Documentation" = "https://aiven-open.github.io/kio/"
 "Bug Tracker" = "https://github.com/Aiven-Open/kio/issues"
 
 [build-system]


### PR DESCRIPTION
This will make the next PyPI release include a link to the docs.