### PR TITLE
chore: Remove version from schema docstrings

### DIFF
--- a/codegen/generate_schema.py
+++ b/codegen/generate_schema.py
@@ -40,15 +40,10 @@ from .parser import PrimitiveArrayType
 from .parser import PrimitiveField
 from .parser import parse_file
 
-schema_repository_source: Final = (
-    f"https://github.com/apache/kafka"
-    f"/tree/{build_tag}/clients/src/main/resources/common/message/"
-)
+schema_repository_source: Final = "clients/src/main/resources/common/message/"
 imports_and_docstring: Final = '''\
 """
-Generated from {schema_source}.
-
-{schema_repository_source}{schema_source}
+Generated from ``{schema_repository_source}{schema_source}``.
 """
 
 import datetime

--- a/src/kio/schema/add_offsets_to_txn/v0/request.py
+++ b/src/kio/schema/add_offsets_to_txn/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddOffsetsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_offsets_to_txn/v0/response.py
+++ b/src/kio/schema/add_offsets_to_txn/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddOffsetsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_offsets_to_txn/v1/request.py
+++ b/src/kio/schema/add_offsets_to_txn/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddOffsetsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_offsets_to_txn/v1/response.py
+++ b/src/kio/schema/add_offsets_to_txn/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddOffsetsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_offsets_to_txn/v2/request.py
+++ b/src/kio/schema/add_offsets_to_txn/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddOffsetsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_offsets_to_txn/v2/response.py
+++ b/src/kio/schema/add_offsets_to_txn/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddOffsetsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_offsets_to_txn/v3/request.py
+++ b/src/kio/schema/add_offsets_to_txn/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddOffsetsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddOffsetsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_offsets_to_txn/v3/response.py
+++ b/src/kio/schema/add_offsets_to_txn/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddOffsetsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddOffsetsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v0/request.py
+++ b/src/kio/schema/add_partitions_to_txn/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v0/response.py
+++ b/src/kio/schema/add_partitions_to_txn/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v1/request.py
+++ b/src/kio/schema/add_partitions_to_txn/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v1/response.py
+++ b/src/kio/schema/add_partitions_to_txn/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v2/request.py
+++ b/src/kio/schema/add_partitions_to_txn/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v2/response.py
+++ b/src/kio/schema/add_partitions_to_txn/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v3/request.py
+++ b/src/kio/schema/add_partitions_to_txn/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v3/response.py
+++ b/src/kio/schema/add_partitions_to_txn/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v4/request.py
+++ b/src/kio/schema/add_partitions_to_txn/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/add_partitions_to_txn/v4/response.py
+++ b/src/kio/schema/add_partitions_to_txn/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AddPartitionsToTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/AddPartitionsToTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/allocate_producer_ids/v0/request.py
+++ b/src/kio/schema/allocate_producer_ids/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AllocateProducerIdsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AllocateProducerIdsRequest.json
+Generated from ``clients/src/main/resources/common/message/AllocateProducerIdsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/allocate_producer_ids/v0/response.py
+++ b/src/kio/schema/allocate_producer_ids/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AllocateProducerIdsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AllocateProducerIdsResponse.json
+Generated from ``clients/src/main/resources/common/message/AllocateProducerIdsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_client_quotas/v0/request.py
+++ b/src/kio/schema/alter_client_quotas/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterClientQuotasRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterClientQuotasRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterClientQuotasRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_client_quotas/v0/response.py
+++ b/src/kio/schema/alter_client_quotas/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterClientQuotasResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterClientQuotasResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterClientQuotasResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_client_quotas/v1/request.py
+++ b/src/kio/schema/alter_client_quotas/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterClientQuotasRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterClientQuotasRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterClientQuotasRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_client_quotas/v1/response.py
+++ b/src/kio/schema/alter_client_quotas/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterClientQuotasResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterClientQuotasResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterClientQuotasResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_configs/v0/request.py
+++ b/src/kio/schema/alter_configs/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_configs/v0/response.py
+++ b/src/kio/schema/alter_configs/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_configs/v1/request.py
+++ b/src/kio/schema/alter_configs/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_configs/v1/response.py
+++ b/src/kio/schema/alter_configs/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_configs/v2/request.py
+++ b/src/kio/schema/alter_configs/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_configs/v2/response.py
+++ b/src/kio/schema/alter_configs/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_partition/v0/request.py
+++ b/src/kio/schema/alter_partition/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_partition/v0/response.py
+++ b/src/kio/schema/alter_partition/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_partition/v1/request.py
+++ b/src/kio/schema/alter_partition/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_partition/v1/response.py
+++ b/src/kio/schema/alter_partition/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_partition/v2/request.py
+++ b/src/kio/schema/alter_partition/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/alter_partition/v2/response.py
+++ b/src/kio/schema/alter_partition/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/alter_partition/v3/request.py
+++ b/src/kio/schema/alter_partition/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/alter_partition/v3/response.py
+++ b/src/kio/schema/alter_partition/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/alter_partition_reassignments/v0/request.py
+++ b/src/kio/schema/alter_partition_reassignments/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionReassignmentsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionReassignmentsRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionReassignmentsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/alter_partition_reassignments/v0/response.py
+++ b/src/kio/schema/alter_partition_reassignments/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterPartitionReassignmentsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterPartitionReassignmentsResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterPartitionReassignmentsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_replica_log_dirs/v0/request.py
+++ b/src/kio/schema/alter_replica_log_dirs/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterReplicaLogDirsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterReplicaLogDirsRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterReplicaLogDirsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_replica_log_dirs/v0/response.py
+++ b/src/kio/schema/alter_replica_log_dirs/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterReplicaLogDirsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterReplicaLogDirsResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterReplicaLogDirsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_replica_log_dirs/v1/request.py
+++ b/src/kio/schema/alter_replica_log_dirs/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterReplicaLogDirsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterReplicaLogDirsRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterReplicaLogDirsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_replica_log_dirs/v1/response.py
+++ b/src/kio/schema/alter_replica_log_dirs/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterReplicaLogDirsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterReplicaLogDirsResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterReplicaLogDirsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_replica_log_dirs/v2/request.py
+++ b/src/kio/schema/alter_replica_log_dirs/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterReplicaLogDirsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterReplicaLogDirsRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterReplicaLogDirsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_replica_log_dirs/v2/response.py
+++ b/src/kio/schema/alter_replica_log_dirs/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterReplicaLogDirsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterReplicaLogDirsResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterReplicaLogDirsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_user_scram_credentials/v0/request.py
+++ b/src/kio/schema/alter_user_scram_credentials/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterUserScramCredentialsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterUserScramCredentialsRequest.json
+Generated from ``clients/src/main/resources/common/message/AlterUserScramCredentialsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/alter_user_scram_credentials/v0/response.py
+++ b/src/kio/schema/alter_user_scram_credentials/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from AlterUserScramCredentialsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/AlterUserScramCredentialsResponse.json
+Generated from ``clients/src/main/resources/common/message/AlterUserScramCredentialsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/api_versions/v0/request.py
+++ b/src/kio/schema/api_versions/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ApiVersionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ApiVersionsRequest.json
+Generated from ``clients/src/main/resources/common/message/ApiVersionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/api_versions/v0/response.py
+++ b/src/kio/schema/api_versions/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ApiVersionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ApiVersionsResponse.json
+Generated from ``clients/src/main/resources/common/message/ApiVersionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/api_versions/v1/request.py
+++ b/src/kio/schema/api_versions/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ApiVersionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ApiVersionsRequest.json
+Generated from ``clients/src/main/resources/common/message/ApiVersionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/api_versions/v1/response.py
+++ b/src/kio/schema/api_versions/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ApiVersionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ApiVersionsResponse.json
+Generated from ``clients/src/main/resources/common/message/ApiVersionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/api_versions/v2/request.py
+++ b/src/kio/schema/api_versions/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ApiVersionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ApiVersionsRequest.json
+Generated from ``clients/src/main/resources/common/message/ApiVersionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/api_versions/v2/response.py
+++ b/src/kio/schema/api_versions/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ApiVersionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ApiVersionsResponse.json
+Generated from ``clients/src/main/resources/common/message/ApiVersionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/api_versions/v3/request.py
+++ b/src/kio/schema/api_versions/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ApiVersionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ApiVersionsRequest.json
+Generated from ``clients/src/main/resources/common/message/ApiVersionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/api_versions/v3/response.py
+++ b/src/kio/schema/api_versions/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ApiVersionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ApiVersionsResponse.json
+Generated from ``clients/src/main/resources/common/message/ApiVersionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/begin_quorum_epoch/v0/request.py
+++ b/src/kio/schema/begin_quorum_epoch/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from BeginQuorumEpochRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/BeginQuorumEpochRequest.json
+Generated from ``clients/src/main/resources/common/message/BeginQuorumEpochRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/begin_quorum_epoch/v0/response.py
+++ b/src/kio/schema/begin_quorum_epoch/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from BeginQuorumEpochResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/BeginQuorumEpochResponse.json
+Generated from ``clients/src/main/resources/common/message/BeginQuorumEpochResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/broker_heartbeat/v0/request.py
+++ b/src/kio/schema/broker_heartbeat/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from BrokerHeartbeatRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/BrokerHeartbeatRequest.json
+Generated from ``clients/src/main/resources/common/message/BrokerHeartbeatRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/broker_heartbeat/v0/response.py
+++ b/src/kio/schema/broker_heartbeat/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from BrokerHeartbeatResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/BrokerHeartbeatResponse.json
+Generated from ``clients/src/main/resources/common/message/BrokerHeartbeatResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/broker_registration/v0/request.py
+++ b/src/kio/schema/broker_registration/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from BrokerRegistrationRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
+Generated from ``clients/src/main/resources/common/message/BrokerRegistrationRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/broker_registration/v0/response.py
+++ b/src/kio/schema/broker_registration/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from BrokerRegistrationResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/BrokerRegistrationResponse.json
+Generated from ``clients/src/main/resources/common/message/BrokerRegistrationResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/broker_registration/v1/request.py
+++ b/src/kio/schema/broker_registration/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from BrokerRegistrationRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/BrokerRegistrationRequest.json
+Generated from ``clients/src/main/resources/common/message/BrokerRegistrationRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/broker_registration/v1/response.py
+++ b/src/kio/schema/broker_registration/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from BrokerRegistrationResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/BrokerRegistrationResponse.json
+Generated from ``clients/src/main/resources/common/message/BrokerRegistrationResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/consumer_group_heartbeat/v0/request.py
+++ b/src/kio/schema/consumer_group_heartbeat/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerGroupHeartbeatRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerGroupHeartbeatRequest.json
+Generated from ``clients/src/main/resources/common/message/ConsumerGroupHeartbeatRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/consumer_group_heartbeat/v0/response.py
+++ b/src/kio/schema/consumer_group_heartbeat/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerGroupHeartbeatResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerGroupHeartbeatResponse.json
+Generated from ``clients/src/main/resources/common/message/ConsumerGroupHeartbeatResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/consumer_protocol_assignment/v0/data.py
+++ b/src/kio/schema/consumer_protocol_assignment/v0/data.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerProtocolAssignment.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerProtocolAssignment.json
+Generated from ``clients/src/main/resources/common/message/ConsumerProtocolAssignment.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/consumer_protocol_assignment/v1/data.py
+++ b/src/kio/schema/consumer_protocol_assignment/v1/data.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerProtocolAssignment.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerProtocolAssignment.json
+Generated from ``clients/src/main/resources/common/message/ConsumerProtocolAssignment.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/consumer_protocol_assignment/v2/data.py
+++ b/src/kio/schema/consumer_protocol_assignment/v2/data.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerProtocolAssignment.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerProtocolAssignment.json
+Generated from ``clients/src/main/resources/common/message/ConsumerProtocolAssignment.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/consumer_protocol_assignment/v3/data.py
+++ b/src/kio/schema/consumer_protocol_assignment/v3/data.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerProtocolAssignment.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerProtocolAssignment.json
+Generated from ``clients/src/main/resources/common/message/ConsumerProtocolAssignment.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/consumer_protocol_subscription/v0/data.py
+++ b/src/kio/schema/consumer_protocol_subscription/v0/data.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerProtocolSubscription.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
+Generated from ``clients/src/main/resources/common/message/ConsumerProtocolSubscription.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/consumer_protocol_subscription/v1/data.py
+++ b/src/kio/schema/consumer_protocol_subscription/v1/data.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerProtocolSubscription.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
+Generated from ``clients/src/main/resources/common/message/ConsumerProtocolSubscription.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/consumer_protocol_subscription/v2/data.py
+++ b/src/kio/schema/consumer_protocol_subscription/v2/data.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerProtocolSubscription.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
+Generated from ``clients/src/main/resources/common/message/ConsumerProtocolSubscription.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/consumer_protocol_subscription/v3/data.py
+++ b/src/kio/schema/consumer_protocol_subscription/v3/data.py
@@ -1,7 +1,5 @@
 """
-Generated from ConsumerProtocolSubscription.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ConsumerProtocolSubscription.json
+Generated from ``clients/src/main/resources/common/message/ConsumerProtocolSubscription.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/controlled_shutdown/v0/request.py
+++ b/src/kio/schema/controlled_shutdown/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ControlledShutdownRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ControlledShutdownRequest.json
+Generated from ``clients/src/main/resources/common/message/ControlledShutdownRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/controlled_shutdown/v0/response.py
+++ b/src/kio/schema/controlled_shutdown/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ControlledShutdownResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ControlledShutdownResponse.json
+Generated from ``clients/src/main/resources/common/message/ControlledShutdownResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/controlled_shutdown/v1/request.py
+++ b/src/kio/schema/controlled_shutdown/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ControlledShutdownRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ControlledShutdownRequest.json
+Generated from ``clients/src/main/resources/common/message/ControlledShutdownRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/controlled_shutdown/v1/response.py
+++ b/src/kio/schema/controlled_shutdown/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ControlledShutdownResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ControlledShutdownResponse.json
+Generated from ``clients/src/main/resources/common/message/ControlledShutdownResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/controlled_shutdown/v2/request.py
+++ b/src/kio/schema/controlled_shutdown/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ControlledShutdownRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ControlledShutdownRequest.json
+Generated from ``clients/src/main/resources/common/message/ControlledShutdownRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/controlled_shutdown/v2/response.py
+++ b/src/kio/schema/controlled_shutdown/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ControlledShutdownResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ControlledShutdownResponse.json
+Generated from ``clients/src/main/resources/common/message/ControlledShutdownResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/controlled_shutdown/v3/request.py
+++ b/src/kio/schema/controlled_shutdown/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ControlledShutdownRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ControlledShutdownRequest.json
+Generated from ``clients/src/main/resources/common/message/ControlledShutdownRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/controlled_shutdown/v3/response.py
+++ b/src/kio/schema/controlled_shutdown/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ControlledShutdownResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ControlledShutdownResponse.json
+Generated from ``clients/src/main/resources/common/message/ControlledShutdownResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_acls/v0/request.py
+++ b/src/kio/schema/create_acls/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_acls/v0/response.py
+++ b/src/kio/schema/create_acls/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_acls/v1/request.py
+++ b/src/kio/schema/create_acls/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_acls/v1/response.py
+++ b/src/kio/schema/create_acls/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_acls/v2/request.py
+++ b/src/kio/schema/create_acls/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_acls/v2/response.py
+++ b/src/kio/schema/create_acls/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_acls/v3/request.py
+++ b/src/kio/schema/create_acls/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_acls/v3/response.py
+++ b/src/kio/schema/create_acls/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_delegation_token/v0/request.py
+++ b/src/kio/schema/create_delegation_token/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_delegation_token/v0/response.py
+++ b/src/kio/schema/create_delegation_token/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_delegation_token/v1/request.py
+++ b/src/kio/schema/create_delegation_token/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_delegation_token/v1/response.py
+++ b/src/kio/schema/create_delegation_token/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_delegation_token/v2/request.py
+++ b/src/kio/schema/create_delegation_token/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_delegation_token/v2/response.py
+++ b/src/kio/schema/create_delegation_token/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_delegation_token/v3/request.py
+++ b/src/kio/schema/create_delegation_token/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_delegation_token/v3/response.py
+++ b/src/kio/schema/create_delegation_token/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_partitions/v0/request.py
+++ b/src/kio/schema/create_partitions/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreatePartitionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreatePartitionsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreatePartitionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_partitions/v0/response.py
+++ b/src/kio/schema/create_partitions/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreatePartitionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreatePartitionsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreatePartitionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_partitions/v1/request.py
+++ b/src/kio/schema/create_partitions/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreatePartitionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreatePartitionsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreatePartitionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_partitions/v1/response.py
+++ b/src/kio/schema/create_partitions/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreatePartitionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreatePartitionsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreatePartitionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_partitions/v2/request.py
+++ b/src/kio/schema/create_partitions/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreatePartitionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreatePartitionsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreatePartitionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_partitions/v2/response.py
+++ b/src/kio/schema/create_partitions/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreatePartitionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreatePartitionsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreatePartitionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_partitions/v3/request.py
+++ b/src/kio/schema/create_partitions/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreatePartitionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreatePartitionsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreatePartitionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_partitions/v3/response.py
+++ b/src/kio/schema/create_partitions/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreatePartitionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreatePartitionsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreatePartitionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_topics/v0/request.py
+++ b/src/kio/schema/create_topics/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/create_topics/v0/response.py
+++ b/src/kio/schema/create_topics/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_topics/v1/request.py
+++ b/src/kio/schema/create_topics/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/create_topics/v1/response.py
+++ b/src/kio/schema/create_topics/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_topics/v2/request.py
+++ b/src/kio/schema/create_topics/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/create_topics/v2/response.py
+++ b/src/kio/schema/create_topics/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_topics/v3/request.py
+++ b/src/kio/schema/create_topics/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/create_topics/v3/response.py
+++ b/src/kio/schema/create_topics/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_topics/v4/request.py
+++ b/src/kio/schema/create_topics/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/create_topics/v4/response.py
+++ b/src/kio/schema/create_topics/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_topics/v5/request.py
+++ b/src/kio/schema/create_topics/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/create_topics/v5/response.py
+++ b/src/kio/schema/create_topics/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_topics/v6/request.py
+++ b/src/kio/schema/create_topics/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/create_topics/v6/response.py
+++ b/src/kio/schema/create_topics/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/create_topics/v7/request.py
+++ b/src/kio/schema/create_topics/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/create_topics/v7/response.py
+++ b/src/kio/schema/create_topics/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from CreateTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/CreateTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/CreateTopicsResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/default_principal_data/v0/data.py
+++ b/src/kio/schema/default_principal_data/v0/data.py
@@ -1,7 +1,5 @@
 """
-Generated from DefaultPrincipalData.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DefaultPrincipalData.json
+Generated from ``clients/src/main/resources/common/message/DefaultPrincipalData.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_acls/v0/request.py
+++ b/src/kio/schema/delete_acls/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_acls/v0/response.py
+++ b/src/kio/schema/delete_acls/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_acls/v1/request.py
+++ b/src/kio/schema/delete_acls/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_acls/v1/response.py
+++ b/src/kio/schema/delete_acls/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_acls/v2/request.py
+++ b/src/kio/schema/delete_acls/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_acls/v2/response.py
+++ b/src/kio/schema/delete_acls/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_acls/v3/request.py
+++ b/src/kio/schema/delete_acls/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_acls/v3/response.py
+++ b/src/kio/schema/delete_acls/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_groups/v0/request.py
+++ b/src/kio/schema/delete_groups/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_groups/v0/response.py
+++ b/src/kio/schema/delete_groups/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_groups/v1/request.py
+++ b/src/kio/schema/delete_groups/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_groups/v1/response.py
+++ b/src/kio/schema/delete_groups/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_groups/v2/request.py
+++ b/src/kio/schema/delete_groups/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_groups/v2/response.py
+++ b/src/kio/schema/delete_groups/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_records/v0/request.py
+++ b/src/kio/schema/delete_records/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteRecordsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteRecordsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteRecordsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_records/v0/response.py
+++ b/src/kio/schema/delete_records/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteRecordsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteRecordsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteRecordsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_records/v1/request.py
+++ b/src/kio/schema/delete_records/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteRecordsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteRecordsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteRecordsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_records/v1/response.py
+++ b/src/kio/schema/delete_records/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteRecordsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteRecordsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteRecordsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_records/v2/request.py
+++ b/src/kio/schema/delete_records/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteRecordsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteRecordsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteRecordsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_records/v2/response.py
+++ b/src/kio/schema/delete_records/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteRecordsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteRecordsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteRecordsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v0/request.py
+++ b/src/kio/schema/delete_topics/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v0/response.py
+++ b/src/kio/schema/delete_topics/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v1/request.py
+++ b/src/kio/schema/delete_topics/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v1/response.py
+++ b/src/kio/schema/delete_topics/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v2/request.py
+++ b/src/kio/schema/delete_topics/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v2/response.py
+++ b/src/kio/schema/delete_topics/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v3/request.py
+++ b/src/kio/schema/delete_topics/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v3/response.py
+++ b/src/kio/schema/delete_topics/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v4/request.py
+++ b/src/kio/schema/delete_topics/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v4/response.py
+++ b/src/kio/schema/delete_topics/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v5/request.py
+++ b/src/kio/schema/delete_topics/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v5/response.py
+++ b/src/kio/schema/delete_topics/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/delete_topics/v6/request.py
+++ b/src/kio/schema/delete_topics/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsRequest.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/delete_topics/v6/response.py
+++ b/src/kio/schema/delete_topics/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DeleteTopicsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DeleteTopicsResponse.json
+Generated from ``clients/src/main/resources/common/message/DeleteTopicsResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/describe_acls/v0/request.py
+++ b/src/kio/schema/describe_acls/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_acls/v0/response.py
+++ b/src/kio/schema/describe_acls/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_acls/v1/request.py
+++ b/src/kio/schema/describe_acls/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_acls/v1/response.py
+++ b/src/kio/schema/describe_acls/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_acls/v2/request.py
+++ b/src/kio/schema/describe_acls/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_acls/v2/response.py
+++ b/src/kio/schema/describe_acls/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_acls/v3/request.py
+++ b/src/kio/schema/describe_acls/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeAclsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeAclsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeAclsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_acls/v3/response.py
+++ b/src/kio/schema/describe_acls/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeAclsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeAclsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeAclsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_client_quotas/v0/request.py
+++ b/src/kio/schema/describe_client_quotas/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeClientQuotasRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeClientQuotasRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeClientQuotasRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_client_quotas/v0/response.py
+++ b/src/kio/schema/describe_client_quotas/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeClientQuotasResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeClientQuotasResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeClientQuotasResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_client_quotas/v1/request.py
+++ b/src/kio/schema/describe_client_quotas/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeClientQuotasRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeClientQuotasRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeClientQuotasRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_client_quotas/v1/response.py
+++ b/src/kio/schema/describe_client_quotas/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeClientQuotasResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeClientQuotasResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeClientQuotasResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_cluster/v0/request.py
+++ b/src/kio/schema/describe_cluster/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeClusterRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeClusterRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeClusterRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_cluster/v0/response.py
+++ b/src/kio/schema/describe_cluster/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeClusterResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeClusterResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeClusterResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v0/request.py
+++ b/src/kio/schema/describe_configs/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v0/response.py
+++ b/src/kio/schema/describe_configs/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v1/request.py
+++ b/src/kio/schema/describe_configs/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v1/response.py
+++ b/src/kio/schema/describe_configs/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v2/request.py
+++ b/src/kio/schema/describe_configs/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v2/response.py
+++ b/src/kio/schema/describe_configs/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v3/request.py
+++ b/src/kio/schema/describe_configs/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v3/response.py
+++ b/src/kio/schema/describe_configs/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v4/request.py
+++ b/src/kio/schema/describe_configs/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_configs/v4/response.py
+++ b/src/kio/schema/describe_configs/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_delegation_token/v0/request.py
+++ b/src/kio/schema/describe_delegation_token/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_delegation_token/v0/response.py
+++ b/src/kio/schema/describe_delegation_token/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_delegation_token/v1/request.py
+++ b/src/kio/schema/describe_delegation_token/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_delegation_token/v1/response.py
+++ b/src/kio/schema/describe_delegation_token/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_delegation_token/v2/request.py
+++ b/src/kio/schema/describe_delegation_token/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_delegation_token/v2/response.py
+++ b/src/kio/schema/describe_delegation_token/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_delegation_token/v3/request.py
+++ b/src/kio/schema/describe_delegation_token/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_delegation_token/v3/response.py
+++ b/src/kio/schema/describe_delegation_token/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v0/request.py
+++ b/src/kio/schema/describe_groups/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v0/response.py
+++ b/src/kio/schema/describe_groups/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v1/request.py
+++ b/src/kio/schema/describe_groups/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v1/response.py
+++ b/src/kio/schema/describe_groups/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v2/request.py
+++ b/src/kio/schema/describe_groups/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v2/response.py
+++ b/src/kio/schema/describe_groups/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v3/request.py
+++ b/src/kio/schema/describe_groups/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v3/response.py
+++ b/src/kio/schema/describe_groups/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v4/request.py
+++ b/src/kio/schema/describe_groups/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v4/response.py
+++ b/src/kio/schema/describe_groups/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v5/request.py
+++ b/src/kio/schema/describe_groups/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_groups/v5/response.py
+++ b/src/kio/schema/describe_groups/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v0/request.py
+++ b/src/kio/schema/describe_log_dirs/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v0/response.py
+++ b/src/kio/schema/describe_log_dirs/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v1/request.py
+++ b/src/kio/schema/describe_log_dirs/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v1/response.py
+++ b/src/kio/schema/describe_log_dirs/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v2/request.py
+++ b/src/kio/schema/describe_log_dirs/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v2/response.py
+++ b/src/kio/schema/describe_log_dirs/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v3/request.py
+++ b/src/kio/schema/describe_log_dirs/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v3/response.py
+++ b/src/kio/schema/describe_log_dirs/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v4/request.py
+++ b/src/kio/schema/describe_log_dirs/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_log_dirs/v4/response.py
+++ b/src/kio/schema/describe_log_dirs/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeLogDirsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeLogDirsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeLogDirsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_producers/v0/request.py
+++ b/src/kio/schema/describe_producers/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeProducersRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeProducersRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeProducersRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_producers/v0/response.py
+++ b/src/kio/schema/describe_producers/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeProducersResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeProducersResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeProducersResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_quorum/v0/request.py
+++ b/src/kio/schema/describe_quorum/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeQuorumRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeQuorumRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeQuorumRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_quorum/v0/response.py
+++ b/src/kio/schema/describe_quorum/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeQuorumResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeQuorumResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeQuorumResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_quorum/v1/request.py
+++ b/src/kio/schema/describe_quorum/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeQuorumRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeQuorumRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeQuorumRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_quorum/v1/response.py
+++ b/src/kio/schema/describe_quorum/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeQuorumResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeQuorumResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeQuorumResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_transactions/v0/request.py
+++ b/src/kio/schema/describe_transactions/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeTransactionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeTransactionsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeTransactionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_transactions/v0/response.py
+++ b/src/kio/schema/describe_transactions/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeTransactionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeTransactionsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeTransactionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_user_scram_credentials/v0/request.py
+++ b/src/kio/schema/describe_user_scram_credentials/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeUserScramCredentialsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeUserScramCredentialsRequest.json
+Generated from ``clients/src/main/resources/common/message/DescribeUserScramCredentialsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/describe_user_scram_credentials/v0/response.py
+++ b/src/kio/schema/describe_user_scram_credentials/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from DescribeUserScramCredentialsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/DescribeUserScramCredentialsResponse.json
+Generated from ``clients/src/main/resources/common/message/DescribeUserScramCredentialsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/elect_leaders/v0/request.py
+++ b/src/kio/schema/elect_leaders/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ElectLeadersRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ElectLeadersRequest.json
+Generated from ``clients/src/main/resources/common/message/ElectLeadersRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/elect_leaders/v0/response.py
+++ b/src/kio/schema/elect_leaders/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ElectLeadersResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ElectLeadersResponse.json
+Generated from ``clients/src/main/resources/common/message/ElectLeadersResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/elect_leaders/v1/request.py
+++ b/src/kio/schema/elect_leaders/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ElectLeadersRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ElectLeadersRequest.json
+Generated from ``clients/src/main/resources/common/message/ElectLeadersRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/elect_leaders/v1/response.py
+++ b/src/kio/schema/elect_leaders/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ElectLeadersResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ElectLeadersResponse.json
+Generated from ``clients/src/main/resources/common/message/ElectLeadersResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/elect_leaders/v2/request.py
+++ b/src/kio/schema/elect_leaders/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ElectLeadersRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ElectLeadersRequest.json
+Generated from ``clients/src/main/resources/common/message/ElectLeadersRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/elect_leaders/v2/response.py
+++ b/src/kio/schema/elect_leaders/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ElectLeadersResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ElectLeadersResponse.json
+Generated from ``clients/src/main/resources/common/message/ElectLeadersResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_quorum_epoch/v0/request.py
+++ b/src/kio/schema/end_quorum_epoch/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from EndQuorumEpochRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndQuorumEpochRequest.json
+Generated from ``clients/src/main/resources/common/message/EndQuorumEpochRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_quorum_epoch/v0/response.py
+++ b/src/kio/schema/end_quorum_epoch/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from EndQuorumEpochResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndQuorumEpochResponse.json
+Generated from ``clients/src/main/resources/common/message/EndQuorumEpochResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_txn/v0/request.py
+++ b/src/kio/schema/end_txn/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from EndTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/EndTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_txn/v0/response.py
+++ b/src/kio/schema/end_txn/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from EndTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/EndTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_txn/v1/request.py
+++ b/src/kio/schema/end_txn/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from EndTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/EndTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_txn/v1/response.py
+++ b/src/kio/schema/end_txn/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from EndTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/EndTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_txn/v2/request.py
+++ b/src/kio/schema/end_txn/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from EndTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/EndTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_txn/v2/response.py
+++ b/src/kio/schema/end_txn/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from EndTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/EndTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_txn/v3/request.py
+++ b/src/kio/schema/end_txn/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from EndTxnRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndTxnRequest.json
+Generated from ``clients/src/main/resources/common/message/EndTxnRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/end_txn/v3/response.py
+++ b/src/kio/schema/end_txn/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from EndTxnResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EndTxnResponse.json
+Generated from ``clients/src/main/resources/common/message/EndTxnResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/envelope/v0/request.py
+++ b/src/kio/schema/envelope/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from EnvelopeRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EnvelopeRequest.json
+Generated from ``clients/src/main/resources/common/message/EnvelopeRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/envelope/v0/response.py
+++ b/src/kio/schema/envelope/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from EnvelopeResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/EnvelopeResponse.json
+Generated from ``clients/src/main/resources/common/message/EnvelopeResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/expire_delegation_token/v0/request.py
+++ b/src/kio/schema/expire_delegation_token/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ExpireDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/expire_delegation_token/v0/response.py
+++ b/src/kio/schema/expire_delegation_token/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ExpireDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/expire_delegation_token/v1/request.py
+++ b/src/kio/schema/expire_delegation_token/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ExpireDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/expire_delegation_token/v1/response.py
+++ b/src/kio/schema/expire_delegation_token/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ExpireDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/expire_delegation_token/v2/request.py
+++ b/src/kio/schema/expire_delegation_token/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ExpireDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/ExpireDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/expire_delegation_token/v2/response.py
+++ b/src/kio/schema/expire_delegation_token/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ExpireDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/ExpireDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v0/request.py
+++ b/src/kio/schema/fetch/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v0/response.py
+++ b/src/kio/schema/fetch/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v1/request.py
+++ b/src/kio/schema/fetch/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v1/response.py
+++ b/src/kio/schema/fetch/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v10/request.py
+++ b/src/kio/schema/fetch/v10/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v10/response.py
+++ b/src/kio/schema/fetch/v10/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v11/request.py
+++ b/src/kio/schema/fetch/v11/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v11/response.py
+++ b/src/kio/schema/fetch/v11/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v12/request.py
+++ b/src/kio/schema/fetch/v12/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v12/response.py
+++ b/src/kio/schema/fetch/v12/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v13/request.py
+++ b/src/kio/schema/fetch/v13/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/fetch/v13/response.py
+++ b/src/kio/schema/fetch/v13/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/fetch/v14/request.py
+++ b/src/kio/schema/fetch/v14/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/fetch/v14/response.py
+++ b/src/kio/schema/fetch/v14/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/fetch/v15/request.py
+++ b/src/kio/schema/fetch/v15/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/fetch/v15/response.py
+++ b/src/kio/schema/fetch/v15/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/fetch/v2/request.py
+++ b/src/kio/schema/fetch/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v2/response.py
+++ b/src/kio/schema/fetch/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v3/request.py
+++ b/src/kio/schema/fetch/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v3/response.py
+++ b/src/kio/schema/fetch/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v4/request.py
+++ b/src/kio/schema/fetch/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v4/response.py
+++ b/src/kio/schema/fetch/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v5/request.py
+++ b/src/kio/schema/fetch/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v5/response.py
+++ b/src/kio/schema/fetch/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v6/request.py
+++ b/src/kio/schema/fetch/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v6/response.py
+++ b/src/kio/schema/fetch/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v7/request.py
+++ b/src/kio/schema/fetch/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v7/response.py
+++ b/src/kio/schema/fetch/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v8/request.py
+++ b/src/kio/schema/fetch/v8/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v8/response.py
+++ b/src/kio/schema/fetch/v8/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v9/request.py
+++ b/src/kio/schema/fetch/v9/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch/v9/response.py
+++ b/src/kio/schema/fetch/v9/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch_snapshot/v0/request.py
+++ b/src/kio/schema/fetch_snapshot/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchSnapshotRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchSnapshotRequest.json
+Generated from ``clients/src/main/resources/common/message/FetchSnapshotRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/fetch_snapshot/v0/response.py
+++ b/src/kio/schema/fetch_snapshot/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FetchSnapshotResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FetchSnapshotResponse.json
+Generated from ``clients/src/main/resources/common/message/FetchSnapshotResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v0/request.py
+++ b/src/kio/schema/find_coordinator/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorRequest.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v0/response.py
+++ b/src/kio/schema/find_coordinator/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorResponse.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v1/request.py
+++ b/src/kio/schema/find_coordinator/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorRequest.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v1/response.py
+++ b/src/kio/schema/find_coordinator/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorResponse.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v2/request.py
+++ b/src/kio/schema/find_coordinator/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorRequest.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v2/response.py
+++ b/src/kio/schema/find_coordinator/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorResponse.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v3/request.py
+++ b/src/kio/schema/find_coordinator/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorRequest.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v3/response.py
+++ b/src/kio/schema/find_coordinator/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorResponse.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v4/request.py
+++ b/src/kio/schema/find_coordinator/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorRequest.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/find_coordinator/v4/response.py
+++ b/src/kio/schema/find_coordinator/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from FindCoordinatorResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/FindCoordinatorResponse.json
+Generated from ``clients/src/main/resources/common/message/FindCoordinatorResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v0/request.py
+++ b/src/kio/schema/heartbeat/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatRequest.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v0/response.py
+++ b/src/kio/schema/heartbeat/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatResponse.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v1/request.py
+++ b/src/kio/schema/heartbeat/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatRequest.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v1/response.py
+++ b/src/kio/schema/heartbeat/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatResponse.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v2/request.py
+++ b/src/kio/schema/heartbeat/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatRequest.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v2/response.py
+++ b/src/kio/schema/heartbeat/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatResponse.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v3/request.py
+++ b/src/kio/schema/heartbeat/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatRequest.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v3/response.py
+++ b/src/kio/schema/heartbeat/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatResponse.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v4/request.py
+++ b/src/kio/schema/heartbeat/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatRequest.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/heartbeat/v4/response.py
+++ b/src/kio/schema/heartbeat/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from HeartbeatResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/HeartbeatResponse.json
+Generated from ``clients/src/main/resources/common/message/HeartbeatResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/incremental_alter_configs/v0/request.py
+++ b/src/kio/schema/incremental_alter_configs/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from IncrementalAlterConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/IncrementalAlterConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/IncrementalAlterConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/incremental_alter_configs/v0/response.py
+++ b/src/kio/schema/incremental_alter_configs/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from IncrementalAlterConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/incremental_alter_configs/v1/request.py
+++ b/src/kio/schema/incremental_alter_configs/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from IncrementalAlterConfigsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/IncrementalAlterConfigsRequest.json
+Generated from ``clients/src/main/resources/common/message/IncrementalAlterConfigsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/incremental_alter_configs/v1/response.py
+++ b/src/kio/schema/incremental_alter_configs/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from IncrementalAlterConfigsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json
+Generated from ``clients/src/main/resources/common/message/IncrementalAlterConfigsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v0/request.py
+++ b/src/kio/schema/init_producer_id/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdRequest.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v0/response.py
+++ b/src/kio/schema/init_producer_id/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdResponse.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v1/request.py
+++ b/src/kio/schema/init_producer_id/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdRequest.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v1/response.py
+++ b/src/kio/schema/init_producer_id/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdResponse.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v2/request.py
+++ b/src/kio/schema/init_producer_id/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdRequest.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v2/response.py
+++ b/src/kio/schema/init_producer_id/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdResponse.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v3/request.py
+++ b/src/kio/schema/init_producer_id/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdRequest.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v3/response.py
+++ b/src/kio/schema/init_producer_id/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdResponse.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v4/request.py
+++ b/src/kio/schema/init_producer_id/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdRequest.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/init_producer_id/v4/response.py
+++ b/src/kio/schema/init_producer_id/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from InitProducerIdResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/InitProducerIdResponse.json
+Generated from ``clients/src/main/resources/common/message/InitProducerIdResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v0/request.py
+++ b/src/kio/schema/join_group/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v0/response.py
+++ b/src/kio/schema/join_group/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v1/request.py
+++ b/src/kio/schema/join_group/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v1/response.py
+++ b/src/kio/schema/join_group/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v2/request.py
+++ b/src/kio/schema/join_group/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v2/response.py
+++ b/src/kio/schema/join_group/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v3/request.py
+++ b/src/kio/schema/join_group/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v3/response.py
+++ b/src/kio/schema/join_group/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v4/request.py
+++ b/src/kio/schema/join_group/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v4/response.py
+++ b/src/kio/schema/join_group/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v5/request.py
+++ b/src/kio/schema/join_group/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v5/response.py
+++ b/src/kio/schema/join_group/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v6/request.py
+++ b/src/kio/schema/join_group/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v6/response.py
+++ b/src/kio/schema/join_group/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v7/request.py
+++ b/src/kio/schema/join_group/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v7/response.py
+++ b/src/kio/schema/join_group/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v8/request.py
+++ b/src/kio/schema/join_group/v8/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v8/response.py
+++ b/src/kio/schema/join_group/v8/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/join_group/v9/request.py
+++ b/src/kio/schema/join_group/v9/request.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/join_group/v9/response.py
+++ b/src/kio/schema/join_group/v9/response.py
@@ -1,7 +1,5 @@
 """
-Generated from JoinGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/JoinGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/JoinGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v0/request.py
+++ b/src/kio/schema/leader_and_isr/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v0/response.py
+++ b/src/kio/schema/leader_and_isr/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v1/request.py
+++ b/src/kio/schema/leader_and_isr/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v1/response.py
+++ b/src/kio/schema/leader_and_isr/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v2/request.py
+++ b/src/kio/schema/leader_and_isr/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v2/response.py
+++ b/src/kio/schema/leader_and_isr/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v3/request.py
+++ b/src/kio/schema/leader_and_isr/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v3/response.py
+++ b/src/kio/schema/leader_and_isr/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v4/request.py
+++ b/src/kio/schema/leader_and_isr/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v4/response.py
+++ b/src/kio/schema/leader_and_isr/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leader_and_isr/v5/request.py
+++ b/src/kio/schema/leader_and_isr/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/leader_and_isr/v5/response.py
+++ b/src/kio/schema/leader_and_isr/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/leader_and_isr/v6/request.py
+++ b/src/kio/schema/leader_and_isr/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/leader_and_isr/v6/response.py
+++ b/src/kio/schema/leader_and_isr/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/leader_and_isr/v7/request.py
+++ b/src/kio/schema/leader_and_isr/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/leader_and_isr/v7/response.py
+++ b/src/kio/schema/leader_and_isr/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderAndIsrResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderAndIsrResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaderAndIsrResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/leader_change_message/v0/data.py
+++ b/src/kio/schema/leader_change_message/v0/data.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaderChangeMessage.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaderChangeMessage.json
+Generated from ``clients/src/main/resources/common/message/LeaderChangeMessage.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v0/request.py
+++ b/src/kio/schema/leave_group/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v0/response.py
+++ b/src/kio/schema/leave_group/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v1/request.py
+++ b/src/kio/schema/leave_group/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v1/response.py
+++ b/src/kio/schema/leave_group/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v2/request.py
+++ b/src/kio/schema/leave_group/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v2/response.py
+++ b/src/kio/schema/leave_group/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v3/request.py
+++ b/src/kio/schema/leave_group/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v3/response.py
+++ b/src/kio/schema/leave_group/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v4/request.py
+++ b/src/kio/schema/leave_group/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v4/response.py
+++ b/src/kio/schema/leave_group/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v5/request.py
+++ b/src/kio/schema/leave_group/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/leave_group/v5/response.py
+++ b/src/kio/schema/leave_group/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from LeaveGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/LeaveGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/LeaveGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v0/request.py
+++ b/src/kio/schema/list_groups/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v0/response.py
+++ b/src/kio/schema/list_groups/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v1/request.py
+++ b/src/kio/schema/list_groups/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v1/response.py
+++ b/src/kio/schema/list_groups/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v2/request.py
+++ b/src/kio/schema/list_groups/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v2/response.py
+++ b/src/kio/schema/list_groups/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v3/request.py
+++ b/src/kio/schema/list_groups/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v3/response.py
+++ b/src/kio/schema/list_groups/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v4/request.py
+++ b/src/kio/schema/list_groups/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_groups/v4/response.py
+++ b/src/kio/schema/list_groups/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListGroupsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListGroupsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListGroupsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v0/request.py
+++ b/src/kio/schema/list_offsets/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v0/response.py
+++ b/src/kio/schema/list_offsets/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v1/request.py
+++ b/src/kio/schema/list_offsets/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v1/response.py
+++ b/src/kio/schema/list_offsets/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v2/request.py
+++ b/src/kio/schema/list_offsets/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v2/response.py
+++ b/src/kio/schema/list_offsets/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v3/request.py
+++ b/src/kio/schema/list_offsets/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v3/response.py
+++ b/src/kio/schema/list_offsets/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v4/request.py
+++ b/src/kio/schema/list_offsets/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v4/response.py
+++ b/src/kio/schema/list_offsets/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v5/request.py
+++ b/src/kio/schema/list_offsets/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v5/response.py
+++ b/src/kio/schema/list_offsets/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v6/request.py
+++ b/src/kio/schema/list_offsets/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v6/response.py
+++ b/src/kio/schema/list_offsets/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v7/request.py
+++ b/src/kio/schema/list_offsets/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v7/response.py
+++ b/src/kio/schema/list_offsets/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v8/request.py
+++ b/src/kio/schema/list_offsets/v8/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_offsets/v8/response.py
+++ b/src/kio/schema/list_offsets/v8/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListOffsetsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListOffsetsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListOffsetsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_partition_reassignments/v0/request.py
+++ b/src/kio/schema/list_partition_reassignments/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListPartitionReassignmentsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListPartitionReassignmentsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListPartitionReassignmentsRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/list_partition_reassignments/v0/response.py
+++ b/src/kio/schema/list_partition_reassignments/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListPartitionReassignmentsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListPartitionReassignmentsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListPartitionReassignmentsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_transactions/v0/request.py
+++ b/src/kio/schema/list_transactions/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ListTransactionsRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListTransactionsRequest.json
+Generated from ``clients/src/main/resources/common/message/ListTransactionsRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/list_transactions/v0/response.py
+++ b/src/kio/schema/list_transactions/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ListTransactionsResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ListTransactionsResponse.json
+Generated from ``clients/src/main/resources/common/message/ListTransactionsResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v0/request.py
+++ b/src/kio/schema/metadata/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v0/response.py
+++ b/src/kio/schema/metadata/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v1/request.py
+++ b/src/kio/schema/metadata/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v1/response.py
+++ b/src/kio/schema/metadata/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v10/request.py
+++ b/src/kio/schema/metadata/v10/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/metadata/v10/response.py
+++ b/src/kio/schema/metadata/v10/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/metadata/v11/request.py
+++ b/src/kio/schema/metadata/v11/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/metadata/v11/response.py
+++ b/src/kio/schema/metadata/v11/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/metadata/v12/request.py
+++ b/src/kio/schema/metadata/v12/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/metadata/v12/response.py
+++ b/src/kio/schema/metadata/v12/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 import uuid

--- a/src/kio/schema/metadata/v2/request.py
+++ b/src/kio/schema/metadata/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v2/response.py
+++ b/src/kio/schema/metadata/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v3/request.py
+++ b/src/kio/schema/metadata/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v3/response.py
+++ b/src/kio/schema/metadata/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v4/request.py
+++ b/src/kio/schema/metadata/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v4/response.py
+++ b/src/kio/schema/metadata/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v5/request.py
+++ b/src/kio/schema/metadata/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v5/response.py
+++ b/src/kio/schema/metadata/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v6/request.py
+++ b/src/kio/schema/metadata/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v6/response.py
+++ b/src/kio/schema/metadata/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v7/request.py
+++ b/src/kio/schema/metadata/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v7/response.py
+++ b/src/kio/schema/metadata/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v8/request.py
+++ b/src/kio/schema/metadata/v8/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v8/response.py
+++ b/src/kio/schema/metadata/v8/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v9/request.py
+++ b/src/kio/schema/metadata/v9/request.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/MetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/metadata/v9/response.py
+++ b/src/kio/schema/metadata/v9/response.py
@@ -1,7 +1,5 @@
 """
-Generated from MetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/MetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/MetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v0/request.py
+++ b/src/kio/schema/offset_commit/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v0/response.py
+++ b/src/kio/schema/offset_commit/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v1/request.py
+++ b/src/kio/schema/offset_commit/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v1/response.py
+++ b/src/kio/schema/offset_commit/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v2/request.py
+++ b/src/kio/schema/offset_commit/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/offset_commit/v2/response.py
+++ b/src/kio/schema/offset_commit/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v3/request.py
+++ b/src/kio/schema/offset_commit/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/offset_commit/v3/response.py
+++ b/src/kio/schema/offset_commit/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v4/request.py
+++ b/src/kio/schema/offset_commit/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/offset_commit/v4/response.py
+++ b/src/kio/schema/offset_commit/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v5/request.py
+++ b/src/kio/schema/offset_commit/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v5/response.py
+++ b/src/kio/schema/offset_commit/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v6/request.py
+++ b/src/kio/schema/offset_commit/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v6/response.py
+++ b/src/kio/schema/offset_commit/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v7/request.py
+++ b/src/kio/schema/offset_commit/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v7/response.py
+++ b/src/kio/schema/offset_commit/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v8/request.py
+++ b/src/kio/schema/offset_commit/v8/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v8/response.py
+++ b/src/kio/schema/offset_commit/v8/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v9/request.py
+++ b/src/kio/schema/offset_commit/v9/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_commit/v9/response.py
+++ b/src/kio/schema/offset_commit/v9/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_delete/v0/request.py
+++ b/src/kio/schema/offset_delete/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetDeleteRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetDeleteRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetDeleteRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_delete/v0/response.py
+++ b/src/kio/schema/offset_delete/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetDeleteResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetDeleteResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetDeleteResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v0/request.py
+++ b/src/kio/schema/offset_fetch/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v0/response.py
+++ b/src/kio/schema/offset_fetch/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v1/request.py
+++ b/src/kio/schema/offset_fetch/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v1/response.py
+++ b/src/kio/schema/offset_fetch/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v2/request.py
+++ b/src/kio/schema/offset_fetch/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v2/response.py
+++ b/src/kio/schema/offset_fetch/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v3/request.py
+++ b/src/kio/schema/offset_fetch/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v3/response.py
+++ b/src/kio/schema/offset_fetch/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v4/request.py
+++ b/src/kio/schema/offset_fetch/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v4/response.py
+++ b/src/kio/schema/offset_fetch/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v5/request.py
+++ b/src/kio/schema/offset_fetch/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v5/response.py
+++ b/src/kio/schema/offset_fetch/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v6/request.py
+++ b/src/kio/schema/offset_fetch/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v6/response.py
+++ b/src/kio/schema/offset_fetch/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v7/request.py
+++ b/src/kio/schema/offset_fetch/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v7/response.py
+++ b/src/kio/schema/offset_fetch/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v8/request.py
+++ b/src/kio/schema/offset_fetch/v8/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_fetch/v8/response.py
+++ b/src/kio/schema/offset_fetch/v8/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetFetchResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetFetchResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetFetchResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v0/request.py
+++ b/src/kio/schema/offset_for_leader_epoch/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v0/response.py
+++ b/src/kio/schema/offset_for_leader_epoch/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v1/request.py
+++ b/src/kio/schema/offset_for_leader_epoch/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v1/response.py
+++ b/src/kio/schema/offset_for_leader_epoch/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v2/request.py
+++ b/src/kio/schema/offset_for_leader_epoch/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v2/response.py
+++ b/src/kio/schema/offset_for_leader_epoch/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v3/request.py
+++ b/src/kio/schema/offset_for_leader_epoch/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v3/response.py
+++ b/src/kio/schema/offset_for_leader_epoch/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v4/request.py
+++ b/src/kio/schema/offset_for_leader_epoch/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/offset_for_leader_epoch/v4/response.py
+++ b/src/kio/schema/offset_for_leader_epoch/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from OffsetForLeaderEpochResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json
+Generated from ``clients/src/main/resources/common/message/OffsetForLeaderEpochResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v0/request.py
+++ b/src/kio/schema/produce/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v0/response.py
+++ b/src/kio/schema/produce/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v1/request.py
+++ b/src/kio/schema/produce/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v1/response.py
+++ b/src/kio/schema/produce/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/produce/v2/request.py
+++ b/src/kio/schema/produce/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v2/response.py
+++ b/src/kio/schema/produce/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/produce/v3/request.py
+++ b/src/kio/schema/produce/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v3/response.py
+++ b/src/kio/schema/produce/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/produce/v4/request.py
+++ b/src/kio/schema/produce/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v4/response.py
+++ b/src/kio/schema/produce/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/produce/v5/request.py
+++ b/src/kio/schema/produce/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v5/response.py
+++ b/src/kio/schema/produce/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/produce/v6/request.py
+++ b/src/kio/schema/produce/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v6/response.py
+++ b/src/kio/schema/produce/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/produce/v7/request.py
+++ b/src/kio/schema/produce/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v7/response.py
+++ b/src/kio/schema/produce/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/produce/v8/request.py
+++ b/src/kio/schema/produce/v8/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v8/response.py
+++ b/src/kio/schema/produce/v8/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/produce/v9/request.py
+++ b/src/kio/schema/produce/v9/request.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceRequest.json
+Generated from ``clients/src/main/resources/common/message/ProduceRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/produce/v9/response.py
+++ b/src/kio/schema/produce/v9/response.py
@@ -1,7 +1,5 @@
 """
-Generated from ProduceResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ProduceResponse.json
+Generated from ``clients/src/main/resources/common/message/ProduceResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/renew_delegation_token/v0/request.py
+++ b/src/kio/schema/renew_delegation_token/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from RenewDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/RenewDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/renew_delegation_token/v0/response.py
+++ b/src/kio/schema/renew_delegation_token/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from RenewDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RenewDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/RenewDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/renew_delegation_token/v1/request.py
+++ b/src/kio/schema/renew_delegation_token/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from RenewDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/RenewDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/renew_delegation_token/v1/response.py
+++ b/src/kio/schema/renew_delegation_token/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from RenewDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RenewDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/RenewDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/renew_delegation_token/v2/request.py
+++ b/src/kio/schema/renew_delegation_token/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from RenewDelegationTokenRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RenewDelegationTokenRequest.json
+Generated from ``clients/src/main/resources/common/message/RenewDelegationTokenRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/renew_delegation_token/v2/response.py
+++ b/src/kio/schema/renew_delegation_token/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from RenewDelegationTokenResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RenewDelegationTokenResponse.json
+Generated from ``clients/src/main/resources/common/message/RenewDelegationTokenResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/request_header/v0/header.py
+++ b/src/kio/schema/request_header/v0/header.py
@@ -1,7 +1,5 @@
 """
-Generated from RequestHeader.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RequestHeader.json
+Generated from ``clients/src/main/resources/common/message/RequestHeader.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/request_header/v1/header.py
+++ b/src/kio/schema/request_header/v1/header.py
@@ -1,7 +1,5 @@
 """
-Generated from RequestHeader.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RequestHeader.json
+Generated from ``clients/src/main/resources/common/message/RequestHeader.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/request_header/v2/header.py
+++ b/src/kio/schema/request_header/v2/header.py
@@ -1,7 +1,5 @@
 """
-Generated from RequestHeader.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/RequestHeader.json
+Generated from ``clients/src/main/resources/common/message/RequestHeader.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/response_header/v0/header.py
+++ b/src/kio/schema/response_header/v0/header.py
@@ -1,7 +1,5 @@
 """
-Generated from ResponseHeader.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ResponseHeader.json
+Generated from ``clients/src/main/resources/common/message/ResponseHeader.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/response_header/v1/header.py
+++ b/src/kio/schema/response_header/v1/header.py
@@ -1,7 +1,5 @@
 """
-Generated from ResponseHeader.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/ResponseHeader.json
+Generated from ``clients/src/main/resources/common/message/ResponseHeader.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sasl_authenticate/v0/request.py
+++ b/src/kio/schema/sasl_authenticate/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslAuthenticateRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
+Generated from ``clients/src/main/resources/common/message/SaslAuthenticateRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sasl_authenticate/v0/response.py
+++ b/src/kio/schema/sasl_authenticate/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslAuthenticateResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
+Generated from ``clients/src/main/resources/common/message/SaslAuthenticateResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sasl_authenticate/v1/request.py
+++ b/src/kio/schema/sasl_authenticate/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslAuthenticateRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
+Generated from ``clients/src/main/resources/common/message/SaslAuthenticateRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sasl_authenticate/v1/response.py
+++ b/src/kio/schema/sasl_authenticate/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslAuthenticateResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
+Generated from ``clients/src/main/resources/common/message/SaslAuthenticateResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/sasl_authenticate/v2/request.py
+++ b/src/kio/schema/sasl_authenticate/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslAuthenticateRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslAuthenticateRequest.json
+Generated from ``clients/src/main/resources/common/message/SaslAuthenticateRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sasl_authenticate/v2/response.py
+++ b/src/kio/schema/sasl_authenticate/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslAuthenticateResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslAuthenticateResponse.json
+Generated from ``clients/src/main/resources/common/message/SaslAuthenticateResponse.json``.
 """
 
 import datetime

--- a/src/kio/schema/sasl_handshake/v0/request.py
+++ b/src/kio/schema/sasl_handshake/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslHandshakeRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslHandshakeRequest.json
+Generated from ``clients/src/main/resources/common/message/SaslHandshakeRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sasl_handshake/v0/response.py
+++ b/src/kio/schema/sasl_handshake/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslHandshakeResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslHandshakeResponse.json
+Generated from ``clients/src/main/resources/common/message/SaslHandshakeResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sasl_handshake/v1/request.py
+++ b/src/kio/schema/sasl_handshake/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslHandshakeRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslHandshakeRequest.json
+Generated from ``clients/src/main/resources/common/message/SaslHandshakeRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sasl_handshake/v1/response.py
+++ b/src/kio/schema/sasl_handshake/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SaslHandshakeResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SaslHandshakeResponse.json
+Generated from ``clients/src/main/resources/common/message/SaslHandshakeResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/snapshot_footer_record/v0/data.py
+++ b/src/kio/schema/snapshot_footer_record/v0/data.py
@@ -1,7 +1,5 @@
 """
-Generated from SnapshotFooterRecord.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SnapshotFooterRecord.json
+Generated from ``clients/src/main/resources/common/message/SnapshotFooterRecord.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/snapshot_header_record/v0/data.py
+++ b/src/kio/schema/snapshot_header_record/v0/data.py
@@ -1,7 +1,5 @@
 """
-Generated from SnapshotHeaderRecord.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SnapshotHeaderRecord.json
+Generated from ``clients/src/main/resources/common/message/SnapshotHeaderRecord.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v0/request.py
+++ b/src/kio/schema/stop_replica/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaRequest.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v0/response.py
+++ b/src/kio/schema/stop_replica/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaResponse.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v1/request.py
+++ b/src/kio/schema/stop_replica/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaRequest.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v1/response.py
+++ b/src/kio/schema/stop_replica/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaResponse.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v2/request.py
+++ b/src/kio/schema/stop_replica/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaRequest.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v2/response.py
+++ b/src/kio/schema/stop_replica/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaResponse.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v3/request.py
+++ b/src/kio/schema/stop_replica/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaRequest.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v3/response.py
+++ b/src/kio/schema/stop_replica/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaResponse.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v4/request.py
+++ b/src/kio/schema/stop_replica/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaRequest.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/stop_replica/v4/response.py
+++ b/src/kio/schema/stop_replica/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from StopReplicaResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/StopReplicaResponse.json
+Generated from ``clients/src/main/resources/common/message/StopReplicaResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v0/request.py
+++ b/src/kio/schema/sync_group/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v0/response.py
+++ b/src/kio/schema/sync_group/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v1/request.py
+++ b/src/kio/schema/sync_group/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v1/response.py
+++ b/src/kio/schema/sync_group/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v2/request.py
+++ b/src/kio/schema/sync_group/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v2/response.py
+++ b/src/kio/schema/sync_group/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v3/request.py
+++ b/src/kio/schema/sync_group/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v3/response.py
+++ b/src/kio/schema/sync_group/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v4/request.py
+++ b/src/kio/schema/sync_group/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v4/response.py
+++ b/src/kio/schema/sync_group/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v5/request.py
+++ b/src/kio/schema/sync_group/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupRequest.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/sync_group/v5/response.py
+++ b/src/kio/schema/sync_group/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from SyncGroupResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/SyncGroupResponse.json
+Generated from ``clients/src/main/resources/common/message/SyncGroupResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/txn_offset_commit/v0/request.py
+++ b/src/kio/schema/txn_offset_commit/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from TxnOffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/TxnOffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/txn_offset_commit/v0/response.py
+++ b/src/kio/schema/txn_offset_commit/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from TxnOffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/TxnOffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/TxnOffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/txn_offset_commit/v1/request.py
+++ b/src/kio/schema/txn_offset_commit/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from TxnOffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/TxnOffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/txn_offset_commit/v1/response.py
+++ b/src/kio/schema/txn_offset_commit/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from TxnOffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/TxnOffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/TxnOffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/txn_offset_commit/v2/request.py
+++ b/src/kio/schema/txn_offset_commit/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from TxnOffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/TxnOffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/txn_offset_commit/v2/response.py
+++ b/src/kio/schema/txn_offset_commit/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from TxnOffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/TxnOffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/TxnOffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/txn_offset_commit/v3/request.py
+++ b/src/kio/schema/txn_offset_commit/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from TxnOffsetCommitRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/TxnOffsetCommitRequest.json
+Generated from ``clients/src/main/resources/common/message/TxnOffsetCommitRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/txn_offset_commit/v3/response.py
+++ b/src/kio/schema/txn_offset_commit/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from TxnOffsetCommitResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/TxnOffsetCommitResponse.json
+Generated from ``clients/src/main/resources/common/message/TxnOffsetCommitResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/unregister_broker/v0/request.py
+++ b/src/kio/schema/unregister_broker/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UnregisterBrokerRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UnregisterBrokerRequest.json
+Generated from ``clients/src/main/resources/common/message/UnregisterBrokerRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/unregister_broker/v0/response.py
+++ b/src/kio/schema/unregister_broker/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UnregisterBrokerResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UnregisterBrokerResponse.json
+Generated from ``clients/src/main/resources/common/message/UnregisterBrokerResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_features/v0/request.py
+++ b/src/kio/schema/update_features/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateFeaturesRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateFeaturesRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateFeaturesRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/update_features/v0/response.py
+++ b/src/kio/schema/update_features/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateFeaturesResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateFeaturesResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateFeaturesResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_features/v1/request.py
+++ b/src/kio/schema/update_features/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateFeaturesRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateFeaturesRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateFeaturesRequest.json``.
 """
 
 import datetime

--- a/src/kio/schema/update_features/v1/response.py
+++ b/src/kio/schema/update_features/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateFeaturesResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateFeaturesResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateFeaturesResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v0/request.py
+++ b/src/kio/schema/update_metadata/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v0/response.py
+++ b/src/kio/schema/update_metadata/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v1/request.py
+++ b/src/kio/schema/update_metadata/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v1/response.py
+++ b/src/kio/schema/update_metadata/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v2/request.py
+++ b/src/kio/schema/update_metadata/v2/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v2/response.py
+++ b/src/kio/schema/update_metadata/v2/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v3/request.py
+++ b/src/kio/schema/update_metadata/v3/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v3/response.py
+++ b/src/kio/schema/update_metadata/v3/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v4/request.py
+++ b/src/kio/schema/update_metadata/v4/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v4/response.py
+++ b/src/kio/schema/update_metadata/v4/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v5/request.py
+++ b/src/kio/schema/update_metadata/v5/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v5/response.py
+++ b/src/kio/schema/update_metadata/v5/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v6/request.py
+++ b/src/kio/schema/update_metadata/v6/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v6/response.py
+++ b/src/kio/schema/update_metadata/v6/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v7/request.py
+++ b/src/kio/schema/update_metadata/v7/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/update_metadata/v7/response.py
+++ b/src/kio/schema/update_metadata/v7/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/update_metadata/v8/request.py
+++ b/src/kio/schema/update_metadata/v8/request.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataRequest.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataRequest.json``.
 """
 
 import uuid

--- a/src/kio/schema/update_metadata/v8/response.py
+++ b/src/kio/schema/update_metadata/v8/response.py
@@ -1,7 +1,5 @@
 """
-Generated from UpdateMetadataResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/UpdateMetadataResponse.json
+Generated from ``clients/src/main/resources/common/message/UpdateMetadataResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/vote/v0/request.py
+++ b/src/kio/schema/vote/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from VoteRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/VoteRequest.json
+Generated from ``clients/src/main/resources/common/message/VoteRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/vote/v0/response.py
+++ b/src/kio/schema/vote/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from VoteResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/VoteResponse.json
+Generated from ``clients/src/main/resources/common/message/VoteResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/write_txn_markers/v0/request.py
+++ b/src/kio/schema/write_txn_markers/v0/request.py
@@ -1,7 +1,5 @@
 """
-Generated from WriteTxnMarkersRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/WriteTxnMarkersRequest.json
+Generated from ``clients/src/main/resources/common/message/WriteTxnMarkersRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/write_txn_markers/v0/response.py
+++ b/src/kio/schema/write_txn_markers/v0/response.py
@@ -1,7 +1,5 @@
 """
-Generated from WriteTxnMarkersResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/WriteTxnMarkersResponse.json
+Generated from ``clients/src/main/resources/common/message/WriteTxnMarkersResponse.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/write_txn_markers/v1/request.py
+++ b/src/kio/schema/write_txn_markers/v1/request.py
@@ -1,7 +1,5 @@
 """
-Generated from WriteTxnMarkersRequest.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/WriteTxnMarkersRequest.json
+Generated from ``clients/src/main/resources/common/message/WriteTxnMarkersRequest.json``.
 """
 
 from dataclasses import dataclass

--- a/src/kio/schema/write_txn_markers/v1/response.py
+++ b/src/kio/schema/write_txn_markers/v1/response.py
@@ -1,7 +1,5 @@
 """
-Generated from WriteTxnMarkersResponse.json.
-
-https://github.com/apache/kafka/tree/3.6.0/clients/src/main/resources/common/message/WriteTxnMarkersResponse.json
+Generated from ``clients/src/main/resources/common/message/WriteTxnMarkersResponse.json``.
 """
 
 from dataclasses import dataclass


### PR DESCRIPTION
Please see separate commits, second one has the schema re-generation.

This addresses a regret. While it's nice to have the full link to the upstream source easily available, this just causes an unjustified amount of churn when rebuilding the schema for a new upstream version. I plan to rebuild the schema for upstream version 3.7 soon, and I want to get this merged beforehand. Being able to see exactly which APIs that changes during a schema update will be more valuable then having the convenience of the link.