### PR TITLE
fix: Address circular dependency in codegen

### DIFF
--- a/codegen/__init__.py
+++ b/codegen/__init__.py
@@ -1,3 +1,5 @@
 from typing import Final
 
+# Note: the kafka-clients dependency of the Java tester also needs updating when
+# this is bumped (in java_tester/build.gradle).
 build_tag: Final = "3.6.0"

--- a/codegen/generate_index.py
+++ b/codegen/generate_index.py
@@ -1,20 +1,27 @@
 # ruff: noqa: T201
 
+from __future__ import annotations
+
 import sys
 
 from collections import defaultdict
 from collections.abc import Iterator
 from collections.abc import Mapping
 from functools import partial
+from typing import TYPE_CHECKING
 from typing import Final
 from typing import NamedTuple
 from typing import TypeAlias
 
 from kio.static.constants import EntityType
-from kio.static.protocol import Entity
 
 from .introspect_schema import base_dir
 from .introspect_schema import get_message_entities
+
+# Chickens and eggs ...
+if TYPE_CHECKING:
+    from kio.static.protocol import Entity
+
 
 target_path: Final = base_dir / "src/kio/schema/index.py"
 prefix: Final = "kio.schema."

--- a/codegen/introspect_schema.py
+++ b/codegen/introspect_schema.py
@@ -1,14 +1,21 @@
+from __future__ import annotations
+
 from collections.abc import Iterator
 from importlib import import_module
 from pathlib import Path
 from pkgutil import walk_packages
 from types import ModuleType
+from typing import TYPE_CHECKING
 from typing import Final
 
 import kio.schema
 
 from kio.static.constants import EntityType
-from kio.static.protocol import Entity
+
+# Chickens and eggs ...
+if TYPE_CHECKING:
+    from kio.static.protocol import Entity
+
 
 base_dir: Final = Path(__file__).parent.parent.resolve()
 schema_src_dir: Final = Path(kio.schema.__file__).parent.resolve()


### PR DESCRIPTION
This fixes an issue that it wasn't possible to rebuild schema from scratch, as code generation was depending on files it itself generates.