### PR TITLE
chore: Bump build tools versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
           - pytest==7.4.3
           - pydantic==1.10.13
           - hypothesis==6.99.12
-          - types-setuptools==69.2.0.20240317
+          - types-setuptools==78.1.0.20250329
           - types-requests==2.31.0.20240311
 
   - repo: https://github.com/seddonym/import-linter
@@ -72,6 +72,6 @@ repos:
       - id: check-manifest
         args: ["--no-build-isolation"]
         additional_dependencies:
-          - setuptools==75.1.0
-          - setuptools-scm==8.1.0
-          - wheel==0.44.0
+          - setuptools==78.1.0
+          - setuptools-scm==8.2.0
+          - wheel==0.45.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ authors = [
   { name="Anton Agestam", email="anton.agestam@aiven.io" },
 ]
 description = "Python data types for the Apache Kafka® Protocol."
-license = {text = "Apache-2.0 license"}
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
 requires-python = ">=3.11"
 classifiers = [
   "Intended Audience :: Developers",
@@ -49,7 +50,7 @@ all = [
 "Bug Tracker" = "https://github.com/Aiven-Open/kio/issues"
 
 [build-system]
-requires = ["setuptools==75.1.0", "setuptools-scm==8.1.0", "wheel==0.44.0"]
+requires = ["setuptools==78.1.0", "setuptools-scm==8.2.0", "wheel==0.45.1"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
Since the new setuptools version started giving deprecations, this commit also starts using the new license file format, see link.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license