### PR TITLE
chore: Correct CI badge link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align=center>kio</h1>
 
 <p align=center>
-    <a href=https://github.com/aiven/kio/actions?query=workflow%3ACI+branch%3Amain><img src=https://github.com/aiven/kio/workflows/CI/badge.svg alt="CI Build Status"></a>
+    <a href="https://github.com/Aiven-Open/kio/actions/workflows/ci.yaml?query=branch%3Amain"><img src="https://github.com/Aiven-Open/kio/actions/workflows/ci.yaml/badge.svg?branch=main" alt="CI Build Status"></a>
     <a href=https://codecov.io/gh/Aiven-Open/kio><img src="https://codecov.io/gh/Aiven-Open/kio/graph/badge.svg?token=ogJDikql10" alt="Code coverage report"></a>
     <br>
     <a href=https://pypi.org/project/kio/><img src=https://img.shields.io/pypi/v/kio.svg?color=informational&label=PyPI alt="PyPI Package"></a>


### PR DESCRIPTION
It was currently not filtering correctly and showing as failed, even though the failure was on a (draft) PR.